### PR TITLE
Remove Simple Settings functionality and make tool DSL-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,27 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-xml-inspector is a quality assurance tool for XML files that validates configuration settings against standardized requirements. The tool supports both simple settings-based validation and advanced DSL (Domain Specific Language) expression-based validation for complex XML inspection scenarios.
+xml-inspector is a quality assurance tool for XML files that validates configuration settings using DSL (Domain Specific Language) expression-based validation for complex XML inspection scenarios.
 
 **Language**: Python 3.8+
 **Architecture**: Object-oriented with dataclasses for type safety
 
 ## Core Workflow
 
-The tool supports two validation approaches:
-
-### Simple Settings-Based Validation
-1. **Entity Type Selection**: User selects the type of entity (e.g., device settings, configurations)
-2. **XML File Upload**: Upload one or multiple XML files for inspection
-3. **Standard Settings Document**: Upload reference document containing:
-   - Standard setting values
-   - XPath locations for each setting
-4. **Project-Specific Settings**: Upload additional document with project-specific requirements
-5. **XML Inspection**: Tool extracts values from XML files using XPath expressions
-6. **Validation**: Compare extracted values against both standard and project-specific requirements
-7. **Report Generation**: Generate comprehensive report showing passed and failed checks
-
-### Advanced DSL Expression-Based Validation
+### DSL Expression-Based Validation
 1. **DSL Document Creation**: Create JSON documents with complex validation rules using the DSL syntax
 2. **XML File Upload**: Upload XML files for inspection
 3. **Expression Evaluation**: Tool evaluates sophisticated expressions including:
@@ -60,29 +47,26 @@ The tool provides a command-line interface with the following commands:
 
 ### CLI Examples:
 ```bash
-# Basic settings-based inspection
-xml-inspector inspect -x file.xml -s settings.json -t device-config
+# DSL-based inspection
+xml-inspector inspect -x file.xml -d dsl-validation.json
 
-# With project settings and HTML output
-xml-inspector inspect -x file.xml -s standard.json -p project.yaml -t device-config -o report.html -f html
+# Multiple XML files with HTML output
+xml-inspector inspect -x file1.xml -x file2.xml -d dsl-validation.json -o report.html -f html
 
-# DSL-based inspection with complex expressions
-xml-inspector inspect -x config.xml -s dsl-validation.json -t device-config
-
-# Validate settings document structure
-xml-inspector validate-settings -f settings.json
+# Validate DSL document structure
+xml-inspector validate-settings -f dsl-validation.json
 ```
 
 ## Project Structure
 
 - `xml_inspector/` - Main Python package
   - `core/` - Core functionality (XML parsing, inspection engine, DSL evaluator)
-  - `parsers/` - Settings document parsers (JSON/YAML, DSL parser)
-  - `validators/` - XML validation logic (settings-based and DSL-based)
+  - `parsers/` - DSL document parsers (JSON)
+  - `validators/` - DSL-based XML validation logic
   - `reporters/` - Report generation (JSON/HTML)
   - `types/` - Python dataclass type definitions
 - `tests/` - Test suite using pytest
-- `examples/` - Sample XML files and settings documents
+- `examples/` - Sample XML files and DSL documents
 - `spec/` - DSL specification and JSON schema files
 
 ## Key Dependencies
@@ -100,11 +84,8 @@ xml-inspector validate-settings -f settings.json
 - **XmlInspector**: Main orchestrator class that coordinates all components
 - **CLI**: Click-based command-line interface with colored output
 
-### Settings-Based Validation
-- **SettingsParser**: Processes JSON/YAML settings documents with validation
-- **XmlValidator**: Compares extracted XML values against expected values with type conversion
-
 ### DSL Expression-Based Validation  
+- **SettingsParser**: Processes DSL validation documents (JSON format)
 - **DslParser**: Parses DSL validation documents with complex expression trees
 - **DslEvaluator**: Evaluates DSL expressions including:
   - Arithmetic and logical operations
@@ -117,15 +98,11 @@ xml-inspector validate-settings -f settings.json
   - Complex mapping between related XML nodes
 
 ### Reporting
-- **ReportGenerator**: Creates JSON and HTML reports using Jinja2 templates with support for both simple and detailed per-node results
+- **ReportGenerator**: Creates JSON and HTML reports using Jinja2 templates with support for detailed per-node results
 
 ## Type System
 
 The project uses Python dataclasses for type safety:
-
-### Settings-Based Types
-- `Setting`: Individual setting definition
-- `SettingsDocument`: Complete settings document
 
 ### DSL Expression Types
 - `DslExpression`: Recursive expression tree node with operations, arguments, and XPath
@@ -135,7 +112,7 @@ The project uses Python dataclasses for type safety:
 - `DslComparison`: Comparison between two expressions
 
 ### Result Types
-- `ValidationResult`: Result of a single validation check (supports both simple and per-node results)
+- `ValidationResult`: Result of a single DSL validation check (supports per-node results)
 - `NodeValidationResult`: Individual node result for nodeValidation rules
 - `InspectionReport`: Complete inspection report with summary and results
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,18 @@
-# XML Inspector Examples
+# XML Inspector DSL Examples
 
-This directory contains example files demonstrating how to use the XML Inspector tool (Python version).
+This directory contains example files demonstrating how to use the XML Inspector tool with DSL (Domain Specific Language) validation.
 
 ## Files Overview
 
 ### XML Files
 - `xml-files/device-config.xml` - Sample device configuration XML file representing a network router
+- `xml-files/sample-d20me.xml` - Sample D20ME XML file for complex validation scenarios
+- `xml-files/FLANDERH.xml` - Another sample XML file for testing
+- `xml-files/sample-d20me-xpath-discovery.xml` - XML for XPath discovery examples
 
-### Settings Documents
-- `settings/standard-device-settings.json` - Standard settings that apply to all devices
-- `settings/project-specific-settings.yaml` - Additional settings specific to a particular project
+### DSL Documents
+- `settings/d20me-settings.json` - DSL validation document with complex node validation rules
+- `dsl-example.json` - Simple DSL validation example
 
 ## Installation
 
@@ -25,58 +28,33 @@ pip install -r requirements.txt
 
 ## Usage Examples
 
-### Basic Inspection
-Inspect a single XML file against standard settings:
+### Basic DSL Inspection
+Inspect XML files using DSL validation rules:
 
 ```bash
 xml-inspector inspect \
-  --xml examples/xml-files/device-config.xml \
-  --standard examples/settings/standard-device-settings.json \
-  --type device-config
+  --xml examples/xml-files/sample-d20me.xml \
+  --dsl examples/settings/d20me-settings.json
 ```
 
-### Inspection with Project-Specific Settings
-Include both standard and project-specific settings:
+### Multiple XML Files with HTML Output
+Inspect multiple XML files and generate HTML report:
 
 ```bash
 xml-inspector inspect \
+  --xml examples/xml-files/sample-d20me.xml \
   --xml examples/xml-files/device-config.xml \
-  --standard examples/settings/standard-device-settings.json \
-  --project examples/settings/project-specific-settings.yaml \
-  --type device-config \
-  --output report.json
-```
-
-### Multiple XML Files
-Inspect multiple XML files at once:
-
-```bash
-xml-inspector inspect \
-  --xml examples/xml-files/device-config.xml \
-  --xml examples/xml-files/another-device.xml \
-  --standard examples/settings/standard-device-settings.json \
-  --type device-config
-```
-
-### Generate HTML Report
-Create an HTML report for easier viewing:
-
-```bash
-xml-inspector inspect \
-  --xml examples/xml-files/device-config.xml \
-  --standard examples/settings/standard-device-settings.json \
-  --project examples/settings/project-specific-settings.yaml \
-  --type device-config \
+  --dsl examples/settings/d20me-settings.json \
   --output report.html \
   --format html
 ```
 
-### Validate Settings Document
-Verify that a settings document is properly formatted:
+### Validate DSL Document
+Verify that a DSL validation document is properly formatted:
 
 ```bash
 xml-inspector validate-settings \
-  --file examples/settings/standard-device-settings.json
+  --file examples/settings/d20me-settings.json
 ```
 
 ### Using as Python Library
@@ -89,9 +67,8 @@ from xml_inspector import XmlInspector, InspectionOptions
 inspector = XmlInspector()
 
 options = InspectionOptions(
-    xml_files=["examples/xml-files/device-config.xml"],
-    standard_settings_file="examples/settings/standard-device-settings.json",
-    entity_type="device-config",
+    xml_files=["examples/xml-files/sample-d20me.xml"],
+    dsl_settings_file="examples/settings/d20me-settings.json",
     output_path="report.json",
     output_format="json"
 )
@@ -101,6 +78,23 @@ print(f"Total checks: {report.summary.total_checks}")
 print(f"Passed: {report.summary.passed}")
 print(f"Failed: {report.summary.failed}")
 ```
+
+## DSL Features Demonstrated
+
+### Node Validation
+The example DSL documents demonstrate:
+- **Per-node validation**: Validate each node individually with detailed results
+- **Complex mapping**: Map between related XML nodes using dynamic XPath construction
+- **Aggregation**: Sum, count, and other operations across multiple nodes
+- **Conditional logic**: Complex expressions with calculations and comparisons
+
+### Expression Types
+- **existence**: Check if expressions evaluate to truthy values
+- **pattern**: Match expression results against regular expressions
+- **range**: Validate expression results fall within specified bounds
+- **comparison**: Compare expression results with fixed values
+- **computedComparison**: Compare two expressions or use between operations
+- **nodeValidation**: Validate multiple nodes individually with per-node PASS/FAIL results
 
 ## Development
 
@@ -121,9 +115,10 @@ mypy xml_inspector
 
 ## Expected Results
 
-When running the example with both standard and project-specific settings, you should see:
-- **Passed checks**: Most settings should pass as the example XML is designed to be compliant
-- **Any failures**: Will be clearly identified in the report with expected vs actual values
-- **Missing settings**: If any required settings are not found in the XML
+When running the DSL examples, you should see:
+- **Rule-based validation**: Each DSL rule will be evaluated independently
+- **Per-node results**: For nodeValidation rules, you'll get individual results for each node
+- **Complex calculations**: The tool will evaluate sophisticated expressions and aggregations
+- **Detailed reporting**: Comprehensive reports showing which rules passed/failed and why
 
-The generated report will provide a comprehensive overview of all validation results, making it easy to identify configuration issues or compliance gaps.
+The generated report will provide detailed validation results for each DSL rule, making it easy to identify XML structure issues or data inconsistencies.

--- a/tests/parsers/test_settings_parser.py
+++ b/tests/parsers/test_settings_parser.py
@@ -1,234 +1,109 @@
-"""Tests for settings parser functionality."""
+"""Tests for DSL parser functionality."""
 
 import pytest
 import tempfile
 import os
 import json
-import yaml
 
 from xml_inspector.parsers.settings_parser import SettingsParser, SettingsParseError
-from xml_inspector.types import SettingsDocument
+from xml_inspector.types import DslValidationSettings
 
 
 class TestSettingsParser:
-    """Test cases for SettingsParser class."""
+    """Test cases for DSL SettingsParser class."""
     
     @pytest.fixture
     def parser(self):
-        """Create settings parser instance."""
+        """Create DSL parser instance."""
         return SettingsParser()
     
     @pytest.fixture
-    def sample_settings_data(self):
-        """Sample settings data for testing."""
+    def sample_dsl_data(self):
+        """Sample DSL data for testing."""
         return {
-            "entityType": "device-config",
-            "settings": [
+            "validationSettings": [
                 {
-                    "name": "network-ip",
-                    "xpath": "//network/ip/text()",
-                    "expectedValue": "192.168.1.100",
-                    "description": "Device IP address",
-                    "type": "string"
+                    "id": "test_rule_1",
+                    "description": "Test existence rule",
+                    "type": "existence",
+                    "severity": "error",
+                    "expression": {
+                        "op": "value",
+                        "xpath": "//test/node/text()"
+                    }
                 },
                 {
-                    "name": "network-port",
-                    "xpath": "//network/port/text()",
-                    "expectedValue": 8080,
-                    "type": "number"
+                    "id": "test_rule_2", 
+                    "description": "Test comparison rule",
+                    "type": "comparison",
+                    "severity": "warning",
+                    "expression": {
+                        "op": "value",
+                        "xpath": "//test/count/text()",
+                        "dataType": "integer"
+                    },
+                    "operator": ">=",
+                    "value": 5
                 }
-            ],
-            "metadata": {
-                "version": "1.0",
-                "description": "Test settings"
-            }
+            ]
         }
     
-    def test_parse_json_settings(self, parser, sample_settings_data):
-        """Test parsing JSON settings document."""
+    def test_parse_dsl_json_file(self, parser, sample_dsl_data):
+        """Test parsing valid DSL JSON file."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            json.dump(sample_settings_data, f)
-            temp_file = f.name
+            json.dump(sample_dsl_data, f)
+            temp_path = f.name
         
         try:
-            result = parser.parse_settings_document(temp_file)
-            
-            assert result.entity_type == "device-config"
-            assert len(result.settings) == 2
-            assert result.settings[0].name == "network-ip"
-            assert result.settings[0].xpath == "//network/ip/text()"
-            assert result.settings[0].expected_value == "192.168.1.100"
-            assert result.metadata is not None
-            assert result.metadata.version == "1.0"
+            result = parser.parse_settings_document(temp_path)
+            assert isinstance(result, DslValidationSettings)
+            assert len(result.validation_settings) == 2
+            assert result.validation_settings[0].id == "test_rule_1"
+            assert result.validation_settings[0].type == "existence"
+            assert result.validation_settings[1].id == "test_rule_2"
+            assert result.validation_settings[1].type == "comparison"
         finally:
-            os.unlink(temp_file)
+            os.unlink(temp_path)
     
-    def test_parse_yaml_settings(self, parser, sample_settings_data):
-        """Test parsing YAML settings document."""
+    def test_parse_invalid_json(self, parser):
+        """Test parsing invalid JSON file."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write('{"invalid": json}')
+            temp_path = f.name
+        
+        try:
+            with pytest.raises(SettingsParseError, match="Invalid JSON"):
+                parser.parse_settings_document(temp_path)
+        finally:
+            os.unlink(temp_path)
+    
+    def test_parse_missing_validation_settings(self, parser):
+        """Test parsing JSON without validationSettings."""
+        invalid_data = {"otherField": "value"}
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(invalid_data, f)
+            temp_path = f.name
+        
+        try:
+            with pytest.raises(SettingsParseError, match="must contain 'validationSettings'"):
+                parser.parse_settings_document(temp_path)
+        finally:
+            os.unlink(temp_path)
+    
+    def test_parse_non_json_file(self, parser):
+        """Test parsing non-JSON file."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            yaml.dump(sample_settings_data, f)
-            temp_file = f.name
+            f.write('test: value')
+            temp_path = f.name
         
         try:
-            result = parser.parse_settings_document(temp_file)
-            
-            assert result.entity_type == "device-config"
-            assert len(result.settings) == 2
-            assert result.settings[1].name == "network-port"
-            assert result.settings[1].expected_value == 8080
+            with pytest.raises(SettingsParseError, match="Only JSON format is supported"):
+                parser.parse_settings_document(temp_path)
         finally:
-            os.unlink(temp_file)
+            os.unlink(temp_path)
     
-    def test_parse_unsupported_format(self, parser):
-        """Test parsing unsupported file format."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
-            f.write("invalid content")
-            temp_file = f.name
-        
-        try:
-            with pytest.raises(SettingsParseError, match="Unsupported settings file format"):
-                parser.parse_settings_document(temp_file)
-        finally:
-            os.unlink(temp_file)
-    
-    def test_parse_missing_entity_type(self, parser):
-        """Test parsing settings without entity type."""
-        invalid_data = {
-            "settings": []
-        }
-        
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            json.dump(invalid_data, f)
-            temp_file = f.name
-        
-        try:
-            with pytest.raises(SettingsParseError, match="valid entityType"):
-                parser.parse_settings_document(temp_file)
-        finally:
-            os.unlink(temp_file)
-    
-    def test_parse_invalid_settings_array(self, parser):
-        """Test parsing with invalid settings array."""
-        invalid_data = {
-            "entityType": "test",
-            "settings": "not an array"
-        }
-        
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            json.dump(invalid_data, f)
-            temp_file = f.name
-        
-        try:
-            with pytest.raises(SettingsParseError, match="settings array"):
-                parser.parse_settings_document(temp_file)
-        finally:
-            os.unlink(temp_file)
-    
-    def test_merge_settings_documents(self, parser):
-        """Test merging multiple settings documents."""
-        doc1 = SettingsDocument(
-            entity_type="device-config",
-            settings=[
-                type('Setting', (), {
-                    'name': 'setting1',
-                    'xpath': '//test1',
-                    'expected_value': 'value1',
-                    'required': True,
-                    'type': 'string',
-                    'description': None
-                })()
-            ]
-        )
-        
-        doc2 = SettingsDocument(
-            entity_type="device-config",
-            settings=[
-                type('Setting', (), {
-                    'name': 'setting2',
-                    'xpath': '//test2',
-                    'expected_value': 'value2',
-                    'required': True,
-                    'type': 'string',
-                    'description': None
-                })()
-            ]
-        )
-        
-        result = parser.merge_settings_documents([doc1, doc2])
-        
-        assert result.entity_type == "device-config"
-        assert len(result.settings) == 2
-        assert {s.name for s in result.settings} == {'setting1', 'setting2'}
-    
-    def test_merge_documents_with_override(self, parser):
-        """Test merging documents with setting override."""
-        from xml_inspector.types import Setting
-        
-        doc1 = SettingsDocument(
-            entity_type="device-config",
-            settings=[
-                Setting(
-                    name='setting1',
-                    xpath='//test1',
-                    expected_value='value1'
-                )
-            ]
-        )
-        
-        doc2 = SettingsDocument(
-            entity_type="device-config",
-            settings=[
-                Setting(
-                    name='setting1',
-                    xpath='//test1',
-                    expected_value='value2'
-                )
-            ]
-        )
-        
-        result = parser.merge_settings_documents([doc1, doc2])
-        
-        assert len(result.settings) == 1
-        assert result.settings[0].expected_value == 'value2'
-    
-    def test_merge_documents_entity_type_mismatch(self, parser):
-        """Test merging documents with mismatched entity types."""
-        doc1 = SettingsDocument(
-            entity_type="device-config",
-            settings=[]
-        )
-        
-        doc2 = SettingsDocument(
-            entity_type="server-config",
-            settings=[]
-        )
-        
-        with pytest.raises(SettingsParseError, match="Entity type mismatch"):
-            parser.merge_settings_documents([doc1, doc2])
-    
-    def test_parse_snake_case_fields(self, parser):
-        """Test parsing with snake_case field names."""
-        settings_data = {
-            "entity_type": "device-config",  # snake_case instead of camelCase
-            "settings": [
-                {
-                    "name": "test-setting",
-                    "xpath": "//test/text()",
-                    "expected_value": "test-value",  # snake_case
-                    "type": "string"
-                }
-            ]
-        }
-        
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            json.dump(settings_data, f)
-            temp_file = f.name
-        
-        try:
-            result = parser.parse_settings_document(temp_file)
-            
-            assert result.entity_type == "device-config"
-            assert len(result.settings) == 1
-            assert result.settings[0].expected_value == "test-value"
-        finally:
-            os.unlink(temp_file)
+    def test_parse_nonexistent_file(self, parser):
+        """Test parsing non-existent file."""
+        with pytest.raises(SettingsParseError, match="File not found"):
+            parser.parse_settings_document("/nonexistent/file.json")

--- a/xml_inspector/__init__.py
+++ b/xml_inspector/__init__.py
@@ -1,21 +1,22 @@
 """
-XML Inspector - A quality assurance tool for XML files.
+XML Inspector - A DSL-based quality assurance tool for XML files.
 
-This package provides functionality to validate XML files against 
-standardized requirements and generate comprehensive reports.
+This package provides functionality to validate XML files using 
+DSL (Domain Specific Language) expressions and generate comprehensive reports.
 """
 
-from .core.inspector import XmlInspector
+from .core.inspector import XmlInspector, InspectionOptions
 from .core.xml_parser import XmlParser
 from .parsers.settings_parser import SettingsParser
-from .validators.xml_validator import XmlValidator
+from .validators.dsl_validator import DslValidator
 from .reporters.report_generator import ReportGenerator
 
 __version__ = "1.0.0"
 __all__ = [
     "XmlInspector",
+    "InspectionOptions",
     "XmlParser", 
     "SettingsParser",
-    "XmlValidator",
+    "DslValidator",
     "ReportGenerator",
 ]

--- a/xml_inspector/parsers/settings_parser.py
+++ b/xml_inspector/parsers/settings_parser.py
@@ -1,40 +1,37 @@
-"""Settings document parsing functionality."""
+"""DSL document parsing functionality."""
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Union
 import logging
 
-import yaml
-
-from ..types import Setting, SettingsDocument, SettingsMetadata, DslValidationSettings
+from ..types import DslValidationSettings
 from .dsl_parser import DslParser
 
 logger = logging.getLogger(__name__)
 
 
 class SettingsParseError(Exception):
-    """Raised when settings document parsing fails."""
+    """Raised when DSL document parsing fails."""
     pass
 
 
 class SettingsParser:
-    """Handles parsing of settings documents in JSON and YAML formats."""
+    """Handles parsing of DSL validation documents in JSON format."""
     
     def __init__(self):
-        """Initialize the settings parser."""
+        """Initialize the DSL parser."""
         self.dsl_parser = DslParser()
     
-    def parse_settings_document(self, file_path: Union[str, Path]) -> Union[SettingsDocument, DslValidationSettings]:
+    def parse_settings_document(self, file_path: Union[str, Path]) -> DslValidationSettings:
         """
-        Parse a settings document from JSON or YAML file.
-        Automatically detects legacy or DSL format.
+        Parse a DSL validation document from JSON file.
         
         Args:
-            file_path: Path to the settings document
+            file_path: Path to the DSL document
             
         Returns:
-            SettingsDocument object for legacy format or DslValidationSettings for DSL format
+            DslValidationSettings object
             
         Raises:
             SettingsParseError: If parsing fails
@@ -48,177 +45,20 @@ class SettingsParser:
             with open(file_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             
-            extension = file_path.suffix.lower()
+            if file_path.suffix.lower() != '.json':
+                raise SettingsParseError(f"Only JSON format is supported for DSL documents: {file_path.suffix}")
             
-            if extension == '.json':
-                data = self._parse_json_settings(content)
-            elif extension in ['.yaml', '.yml']:
-                data = self._parse_yaml_settings(content)
-            else:
-                raise SettingsParseError(f"Unsupported settings file format: {extension}")
+            data = json.loads(content)
             
-            # Check if this is a DSL format (has validationSettings)
-            if 'validationSettings' in data:
-                return self.dsl_parser._validate_dsl_document(data)
-            else:
-                return self._validate_settings_document(data)
+            # Validate DSL format
+            if 'validationSettings' not in data:
+                raise SettingsParseError("DSL document must contain 'validationSettings' array")
+            
+            return self.dsl_parser._validate_dsl_document(data)
             
         except SettingsParseError:
             raise
-        except Exception as e:
-            raise SettingsParseError(f"Failed to parse settings document {file_path}: {e}")
-    
-    def parse_multiple_settings_documents(self, file_paths: List[Union[str, Path]]) -> List[SettingsDocument]:
-        """
-        Parse multiple settings documents.
-        
-        Args:
-            file_paths: List of paths to settings documents
-            
-        Returns:
-            List of SettingsDocument objects
-        """
-        return [self.parse_settings_document(file_path) for file_path in file_paths]
-    
-    def merge_settings_documents(self, documents: List[SettingsDocument]) -> SettingsDocument:
-        """
-        Merge multiple settings documents into one.
-        
-        Args:
-            documents: List of SettingsDocument objects to merge
-            
-        Returns:
-            Merged SettingsDocument
-            
-        Raises:
-            SettingsParseError: If documents cannot be merged
-        """
-        if not documents:
-            raise SettingsParseError("No settings documents provided for merging")
-        
-        base_document = documents[0]
-        merged_settings: List[Setting] = list(base_document.settings)
-        
-        for i in range(1, len(documents)):
-            current_doc = documents[i]
-            
-            if current_doc.entity_type != base_document.entity_type:
-                raise SettingsParseError(
-                    f"Entity type mismatch: {base_document.entity_type} vs {current_doc.entity_type}"
-                )
-            
-            for setting in current_doc.settings:
-                # Find existing setting with same name
-                existing_index = None
-                for j, existing_setting in enumerate(merged_settings):
-                    if existing_setting.name == setting.name:
-                        existing_index = j
-                        break
-                
-                if existing_index is not None:
-                    # Override existing setting
-                    merged_settings[existing_index] = setting
-                else:
-                    # Add new setting
-                    merged_settings.append(setting)
-        
-        # Create merged metadata
-        merged_metadata = SettingsMetadata(
-            version=base_document.metadata.version if base_document.metadata else None,
-            description="Merged settings document",
-            author=base_document.metadata.author if base_document.metadata else None
-        )
-        
-        return SettingsDocument(
-            entity_type=base_document.entity_type,
-            settings=merged_settings,
-            metadata=merged_metadata
-        )
-    
-    def _parse_json_settings(self, content: str) -> Dict[str, Any]:
-        """Parse JSON settings content."""
-        try:
-            return json.loads(content)
         except json.JSONDecodeError as e:
-            raise SettingsParseError(f"Invalid JSON: {e}")
-    
-    def _parse_yaml_settings(self, content: str) -> Dict[str, Any]:
-        """Parse YAML settings content."""
-        try:
-            return yaml.safe_load(content)
-        except yaml.YAMLError as e:
-            raise SettingsParseError(f"Invalid YAML: {e}")
-    
-    def _validate_settings_document(self, data: Dict[str, Any]) -> SettingsDocument:
-        """
-        Validate and convert parsed data to SettingsDocument.
-        
-        Args:
-            data: Parsed settings data
-            
-        Returns:
-            SettingsDocument object
-            
-        Raises:
-            SettingsParseError: If validation fails
-        """
-        if not isinstance(data, dict):
-            raise SettingsParseError("Settings document must be an object")
-        
-        # Validate entity_type
-        entity_type = data.get('entityType') or data.get('entity_type')
-        if not entity_type or not isinstance(entity_type, str):
-            raise SettingsParseError("Settings document must have a valid entityType or entity_type")
-        
-        # Validate settings array
-        settings_data = data.get('settings', [])
-        if not isinstance(settings_data, list):
-            raise SettingsParseError("Settings document must have a settings array")
-        
-        settings = []
-        for i, setting_data in enumerate(settings_data):
-            if not isinstance(setting_data, dict):
-                raise SettingsParseError(f"Setting at index {i} must be an object")
-            
-            # Validate required fields
-            name = setting_data.get('name')
-            if not name or not isinstance(name, str):
-                raise SettingsParseError(f"Setting at index {i} must have a valid name")
-            
-            xpath = setting_data.get('xpath')
-            if not xpath or not isinstance(xpath, str):
-                raise SettingsParseError(f"Setting at index {i} must have a valid xpath")
-            
-            # Extract and validate optional fields
-            expected_value = setting_data.get('expectedValue') or setting_data.get('expected_value')
-            description = setting_data.get('description')
-            required = setting_data.get('required', True)
-            setting_type = setting_data.get('type', 'string')
-            
-            if setting_type not in ['string', 'number', 'boolean']:
-                setting_type = 'string'
-            
-            settings.append(Setting(
-                name=name,
-                xpath=xpath,
-                expected_value=expected_value,
-                description=description,
-                required=required,
-                type=setting_type  # type: ignore
-            ))
-        
-        # Parse metadata
-        metadata_data = data.get('metadata', {})
-        metadata = None
-        if metadata_data:
-            metadata = SettingsMetadata(
-                version=metadata_data.get('version'),
-                description=metadata_data.get('description'),
-                author=metadata_data.get('author')
-            )
-        
-        return SettingsDocument(
-            entity_type=entity_type,
-            settings=settings,
-            metadata=metadata
-        )
+            raise SettingsParseError(f"Invalid JSON in {file_path}: {e}")
+        except Exception as e:
+            raise SettingsParseError(f"Failed to parse DSL document {file_path}: {e}")

--- a/xml_inspector/reporters/report_generator.py
+++ b/xml_inspector/reporters/report_generator.py
@@ -36,17 +36,15 @@ class ReportGenerator:
         self,
         results: List[ValidationResult],
         xml_files: List[str],
-        settings_documents: List[str],
-        entity_type: str
+        dsl_documents: List[str]
     ) -> InspectionReport:
         """
-        Generate an inspection report from validation results.
+        Generate an inspection report from DSL validation results.
         
         Args:
             results: List of validation results
             xml_files: List of XML file paths that were validated
-            settings_documents: List of settings document paths used
-            entity_type: Type of entity being validated
+            dsl_documents: List of DSL document paths used
             
         Returns:
             InspectionReport object
@@ -54,9 +52,8 @@ class ReportGenerator:
         summary = self._generate_summary(results)
         metadata = ReportMetadata(
             timestamp=datetime.now().isoformat(),
-            entity_type=entity_type,
             xml_files=xml_files,
-            settings_documents=settings_documents
+            dsl_documents=dsl_documents
         )
         
         return InspectionReport(

--- a/xml_inspector/types/__init__.py
+++ b/xml_inspector/types/__init__.py
@@ -1,46 +1,14 @@
-"""Type definitions for XML Inspector."""
+"""Type definitions for XML Inspector DSL validation."""
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union, Any, Literal
-from datetime import datetime
+from dataclasses import dataclass
+from typing import List, Optional, Union, Any, Literal
 
-SettingType = Literal["string", "number", "boolean"]
 ValidationStatus = Literal["pass", "fail", "missing"]
 DslValidationType = Literal["existence", "pattern", "range", "comparison", "computedComparison", "nodeValidation"]
 DslSeverity = Literal["error", "warning", "info"]
 DslDataType = Literal["string", "integer", "decimal", "date"]
 DslComparisonOperator = Literal["==", "!=", ">", "<", ">=", "<=", "between"]
 DslConditionType = Literal["exists", "attributeEquals"]
-
-
-@dataclass
-class Setting:
-    """Represents a single setting to be validated."""
-    
-    name: str
-    xpath: str
-    expected_value: Optional[Union[str, int, float, bool]] = None
-    description: Optional[str] = None
-    required: bool = True
-    type: SettingType = "string"
-
-
-@dataclass
-class SettingsMetadata:
-    """Metadata for settings documents."""
-    
-    version: Optional[str] = None
-    description: Optional[str] = None
-    author: Optional[str] = None
-
-
-@dataclass
-class SettingsDocument:
-    """Represents a complete settings document."""
-    
-    entity_type: str
-    settings: List[Setting]
-    metadata: Optional[SettingsMetadata] = None
 
 
 @dataclass
@@ -57,9 +25,10 @@ class NodeValidationResult:
 
 @dataclass
 class ValidationResult:
-    """Result of validating a single setting."""
+    """Result of validating a DSL rule."""
     
-    setting_name: str
+    rule_id: str
+    rule_description: str
     xpath: str
     expected_value: Optional[Union[str, int, float, bool]]
     actual_value: Optional[Union[str, int, float, bool]]
@@ -85,9 +54,8 @@ class ReportMetadata:
     """Metadata for inspection reports."""
     
     timestamp: str
-    entity_type: str
     xml_files: List[str]
-    settings_documents: List[str]
+    dsl_documents: List[str]
 
 
 @dataclass
@@ -108,7 +76,6 @@ class XmlFile:
 
 
 # Type aliases for convenience
-SettingValue = Union[str, int, float, bool]
 ValidationResults = List[ValidationResult]
 
 

--- a/xml_inspector/validators/dsl_validator.py
+++ b/xml_inspector/validators/dsl_validator.py
@@ -53,7 +53,8 @@ class DslValidator:
                     logger.error(f"Failed to validate rule {rule.id} for file {xml_file.path}: {e}")
                     # Create a failed result for the error
                     results.append(ValidationResult(
-                        setting_name=rule.id,
+                        rule_id=rule.id,
+                        rule_description=rule.description,
                         xpath="N/A",
                         expected_value=None,
                         actual_value=None,
@@ -80,8 +81,9 @@ class DslValidator:
             if not self.evaluator.evaluate_conditions(rule.conditions, xml_file.content):
                 # Conditions not met, skip this rule
                 return ValidationResult(
-                    setting_name=rule.id,
-                    xpath="N/A",
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath="N/A",
                     expected_value=None,
                     actual_value=None,
                     status="pass",  # Skip is considered pass
@@ -107,8 +109,9 @@ class DslValidator:
                 
         except Exception as e:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath="N/A",
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath="N/A",
                 expected_value=None,
                 actual_value=None,
                 status="fail",
@@ -128,8 +131,9 @@ class DslValidator:
             exists = bool(result) and (not isinstance(result, (int, float)) or result > 0)
             
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value="exists",
                 actual_value=str(result),
                 status="pass" if exists else "fail",
@@ -139,8 +143,9 @@ class DslValidator:
             
         except DslEvaluationError as e:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value="exists",
                 actual_value=None,
                 status="fail",
@@ -160,8 +165,9 @@ class DslValidator:
             pattern_match = re.match(rule.pattern, result_str) is not None
             
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value=f"matches pattern: {rule.pattern}",
                 actual_value=result_str,
                 status="pass" if pattern_match else "fail",
@@ -171,8 +177,9 @@ class DslValidator:
             
         except DslEvaluationError as e:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value=f"matches pattern: {rule.pattern}",
                 actual_value=None,
                 status="fail",
@@ -209,8 +216,9 @@ class DslValidator:
             in_range = min_val <= actual_val <= max_val
             
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value=f"between {rule.min_value} and {rule.max_value}",
                 actual_value=str(result),
                 status="pass" if in_range else "fail",
@@ -220,8 +228,9 @@ class DslValidator:
             
         except (DslEvaluationError, ValueError, TypeError) as e:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value=f"between {rule.min_value} and {rule.max_value}",
                 actual_value=None,
                 status="fail",
@@ -255,8 +264,9 @@ class DslValidator:
                 raise DslValidationError(f"Unknown comparison operator: {rule.operator}")
             
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value=f"{rule.operator} {expected}",
                 actual_value=str(result),
                 status="pass" if passes else "fail",
@@ -266,8 +276,9 @@ class DslValidator:
             
         except (DslEvaluationError, ValueError, TypeError) as e:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_expression_xpath(rule.expression),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_expression_xpath(rule.expression),
                 expected_value=f"{rule.operator} {rule.value}",
                 actual_value=None,
                 status="fail",
@@ -325,8 +336,9 @@ class DslValidator:
                 expected_desc = f"{comparison.operator} {right_result}"
             
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_comparison_xpath(comparison),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_comparison_xpath(comparison),
                 expected_value=expected_desc,
                 actual_value=str(actual),
                 status="pass" if passes else "fail",
@@ -336,8 +348,9 @@ class DslValidator:
             
         except (DslEvaluationError, ValueError, TypeError) as e:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=self._get_comparison_xpath(comparison),
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=self._get_comparison_xpath(comparison),
                 expected_value="computed comparison",
                 actual_value=None,
                 status="fail",
@@ -372,8 +385,9 @@ class DslValidator:
         """
         if not rule.nodes_xpath:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath="N/A",
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath="N/A",
                 expected_value=None,
                 actual_value=None,
                 status="fail",
@@ -383,8 +397,9 @@ class DslValidator:
         
         if not rule.node_value_expression:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=rule.nodes_xpath,
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=rule.nodes_xpath,
                 expected_value=None,
                 actual_value=None,
                 status="fail",
@@ -397,8 +412,9 @@ class DslValidator:
             nodes = xml_file.content.xpath(rule.nodes_xpath)
         except Exception as e:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=rule.nodes_xpath,
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=rule.nodes_xpath,
                 expected_value=None,
                 actual_value=None,
                 status="fail",
@@ -408,8 +424,9 @@ class DslValidator:
         
         if not nodes:
             return ValidationResult(
-                setting_name=rule.id,
-                xpath=rule.nodes_xpath,
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=rule.nodes_xpath,
                 expected_value=None,
                 actual_value=None,
                 status="missing",
@@ -484,8 +501,9 @@ class DslValidator:
         summary_msg = f"Node validation: {pass_count} passed, {fail_count} failed"
         
         return ValidationResult(
-            setting_name=rule.id,
-            xpath=rule.nodes_xpath,
+                        rule_id=rule.id,
+                        rule_description=rule.description,
+                        xpath=rule.nodes_xpath,
             expected_value=f"All nodes should pass validation",
             actual_value=f"{pass_count}/{len(node_results)} nodes passed",
             status=overall_status,


### PR DESCRIPTION
This is a major refactoring that removes all Simple Settings validation functionality and makes the tool exclusively use DSL (Domain Specific Language) expression-based validation.

Key Changes:
- Removed Simple Settings types (Setting, SettingsDocument, SettingsMetadata)
- Updated ValidationResult to use rule_id instead of setting_name
- Removed xml_validator.py (simple settings validator)
- Updated CLI to use --dsl parameter instead of --standard/--project
- Simplified XmlInspector to only handle DSL validation
- Updated tests to only test DSL functionality
- Removed YAML support (JSON-only for DSL documents)
- Updated documentation to reflect DSL-only approach
- Fixed DslValidator to use updated ValidationResult constructor

The tool now provides a focused, powerful DSL-based validation system with support for complex expressions, per-node validation, dynamic XPath construction, and sophisticated business rule validation.

Testing verified:
- CLI commands work with new DSL-only interface
- DSL document validation works correctly
- Per-node validation produces detailed results
- HTML and JSON report generation works
- Python library interface works with new structure

🤖 Generated with [Claude Code](https://claude.ai/code)