### PR TITLE
Add DSL validation examples for XML inspector

### DIFF
--- a/examples/output/report-v2.json
+++ b/examples/output/report-v2.json
@@ -1,0 +1,63 @@
+{
+  "summary": {
+    "total_checks": 1,
+    "passed": 1,
+    "failed": 0,
+    "missing": 0
+  },
+  "results": [
+    {
+      "rule_id": "count_binary_input_per_dca_record",
+      "rule_description": "For each DCA CONFIGURATION record, count total Binary Input points using mapping",
+      "xpath": "//B023_CFG/Record",
+      "expected_value": "All nodes should pass validation",
+      "actual_value": "4/4 nodes passed",
+      "status": "pass",
+      "message": "Node validation: 4 passed, 0 failed",
+      "file_path": "examples/xml-files/FLANDERH.xml",
+      "node_results": [
+        {
+          "node_index": 0,
+          "node_xpath": "//B023_CFG/Record[1]",
+          "actual_value": 51.0,
+          "expected_value": 51,
+          "status": "pass",
+          "message": "Node 1: PASS"
+        },
+        {
+          "node_index": 1,
+          "node_xpath": "//B023_CFG/Record[2]",
+          "actual_value": 51.0,
+          "expected_value": 51,
+          "status": "pass",
+          "message": "Node 2: PASS"
+        },
+        {
+          "node_index": 2,
+          "node_xpath": "//B023_CFG/Record[3]",
+          "actual_value": 35.0,
+          "expected_value": 35,
+          "status": "pass",
+          "message": "Node 3: PASS"
+        },
+        {
+          "node_index": 3,
+          "node_xpath": "//B023_CFG/Record[4]",
+          "actual_value": 19.0,
+          "expected_value": 19,
+          "status": "pass",
+          "message": "Node 4: PASS"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "timestamp": "2025-07-28T16:22:57.451383",
+    "xml_files": [
+      "examples/xml-files/FLANDERH.xml"
+    ],
+    "dsl_documents": [
+      "examples/settings/d20me-settings-v2.json"
+    ]
+  }
+}

--- a/examples/settings/analog-input-16-validation.json
+++ b/examples/settings/analog-input-16-validation.json
@@ -1,0 +1,46 @@
+{
+  "validationSettings": [
+    {
+      "id": "analog_input_16_point_validation", 
+      "description": "Validate Analog Input 16 point counts between DCA Configuration and System Point Database",
+      "type": "nodeValidation",
+      "severity": "error",
+      "nodesXpath": "//B023_CFG/Record",
+      "nodeValueExpression": {
+        "op": "sum",
+        "args": [
+          {
+            "op": "map",
+            "xpath": "//B023_PNT/Record[@DCA_x0020_Object_x0020_Type='Analog Input 16']",
+            "expression": {
+              "op": "add",
+              "args": [
+                {"op": "value", "xpath": "@Number_x0020_Of_x0020_Device_x0020_Points", "dataType": "integer"},
+                {"op": "literal", "value": 5}
+              ]
+            }
+          }
+        ]
+      },
+      "expectedValueExpression": {
+        "op": "value",
+        "xpathExpression": {
+          "op": "concat",
+          "args": [
+            "//B008_DCA/Record[position() = ",
+            {
+              "op": "add",
+              "args": [
+                {"op": "value", "xpath": "@DCA_x0020_Index", "dataType": "integer"},
+                {"op": "literal", "value": 1}
+              ]
+            },
+            "]/@NumAI"
+          ]
+        },
+        "dataType": "integer"
+      },
+      "operator": "=="
+    }
+  ]
+}

--- a/examples/xml-files/FLANDERH.xml
+++ b/examples/xml-files/FLANDERH.xml
@@ -1,0 +1,4250 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CCE:Device Device_Name="FLANDERH" Device_Type="D20" LAN_Based="False" Redundant="False" Multiprocessor="False" Description="Flanders Substation" SerialNumber="SAD8686/00" Uncompressed_Config_File="False" Notes="Initial configuration for Franklin Config:FRANKLNA 2/3/11 RBK&#xD;&#xA;Updated with changes needed before install occurred. Communications equip alarm, q745 breaker alarm and breaker designation from OCB to GCB Config:FRANKLNB 5/26/11 RBK&#xD;&#xA;Corrected Comm Equip alarm Config:FRANKLNC 6/6/11 RBK&#xD;&#xA;Corrected Analog mapping C783 MW/MVAR Config:FRANKLND 1/4/12 RBK&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;11/22/2017  Created FLANDERB for MPLS Cutover and removed Dial in Access. Point List Rev C. Rizk/BMcD&#xD;&#xA;&#xD;&#xA;02/05/2018 Changed the name of the S919 to D4 and R918 to D5 based on the one line (D-68407-01 rev. A). Point List Rev D. MAC/BMcD/EPST&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;03/14/2022 Added status and analog inputs for new data concentrator connection. Points List Rev F. Supriya Narisetti/BMcD&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;10/19/2023 Added TWM Failure and TWM Alarm points to a new calculator point Station Non-Critical Alarm (Calc4). Points List Rev H. WO#17352949, SCORES 115130. Config: FLANDERF Anani Afanou/BMcD&#xD;&#xA;&#xD;&#xA;06/26/2024 Rev G. Added Station Critical Calc, updated Station Non-Critical Calc, and added Substation Annunciator Failure point. Point List Rev J. WO#17812008 SCORES 117519. Config FLANDERG....Steven Solis/BMcD&#xD;&#xA;&#xD;&#xA;04/29/2024 Rev H. Added 115/34.5kV Spare TR critical and non-critical alarms. Point List Rev M. Config: FLANDERH. WO#17311239 SCORES#200991. Steven Solis/BMcD" schemaVersion="11.0" xmlns:CCE="http://www.ge.com/CCE/DeviceSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ge.com/CCE/DeviceSchema Device.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd http://www.ge.com/CCE/A001_701 A001_701_AE.xsd http://www.ge.com/CCE/A004-1_303 A004-1_303_AE.xsd http://www.ge.com/CCE/A016-0_200 A016-0_200_AE.xsd http://www.ge.com/CCE/A017_131 A017_131_AE.xsd http://www.ge.com/CCE/A018_120 A018_120_AE.xsd http://www.ge.com/CCE/A020_421 A020_421_AE.xsd http://www.ge.com/CCE/A022_203 A022_203_AE.xsd http://www.ge.com/CCE/A025_302 A025_302_AE.xsd http://www.ge.com/CCE/A026-1_321 A026-1_321_AE.xsd http://www.ge.com/CCE/A027_810 A027_810_AE.xsd http://www.ge.com/CCE/A029_707 A029_707_AE.xsd http://www.ge.com/CCE/A030_300 A030_300_AE.xsd http://www.ge.com/CCE/A031_310 A031_310_AE.xsd http://www.ge.com/CCE/A035_211 A035_211_AE.xsd http://www.ge.com/CCE/A036_421 A036_421_AE.xsd http://www.ge.com/CCE/A059_902 A059_902_AE.xsd http://www.ge.com/CCE/A068_229 A068_229_AE.xsd http://www.ge.com/CCE/A078_609 A078_609_AE.xsd http://www.ge.com/CCE/A083-0_335 A083-0_335_AE.xsd http://www.ge.com/CCE/A092-0_103 A092-0_103_AE.xsd http://www.ge.com/CCE/A185-0_200 A185-0_200_AE.xsd http://www.ge.com/CCE/A194-0_100 A194-0_100_AE.xsd http://www.ge.com/CCE/A199-0_103 A199-0_103_AE.xsd http://www.ge.com/CCE/B003_749 B003_749_AE.xsd http://www.ge.com/CCE/B008-1_304 B008-1_304_AE.xsd http://www.ge.com/CCE/B009_400 B009_400_AE.xsd http://www.ge.com/CCE/B012_112 B012_112_AE.xsd http://www.ge.com/CCE/B013_541 B013_541_AE.xsd http://www.ge.com/CCE/B014-1_412 B014-1_412_AE.xsd http://www.ge.com/CCE/B015_520 B015_520_AE.xsd http://www.ge.com/CCE/B021_972 B021_972_AE.xsd http://www.ge.com/CCE/B023_746 B023_746_AE.xsd http://www.ge.com/CCE/B034_203 B034_203_AE.xsd http://www.ge.com/CCE/B062-0_121 B062-0_121_AE.xsd http://www.ge.com/CCE/B071-0_200 B071-0_200_AE.xsd http://www.ge.com/CCE/B082-1_210 B082-1_210_AE.xsd http://www.ge.com/CCE/CPRO_600 CPRO_600_AE.xsd">
+  <Global_Memory Start_Address="0x00500000" Global_Size="8" Global_NVRAM_Size="2048" Global_RAM_Size="0" Global_Base_Size="1024" Global_NVRAM_Storage_Regions="0" Global_NVRAM_Storage_Size="0" />
+  <Processor_List>
+    <Processor Id="1" Enabled="True" Use_Firmware_Type="True" Firmware_Name="SAB3075" Firmware_Version="010" Part_Number="526-2007 CCU" Derive_From_Memory_Card="True" EPROM_Address="0x00100000" EPROM_Size="2097152" NVRAM_Address="0x00800000" NVRAM_Size="524288" RAM_Address="0x00300000" RAM_Size="1572864" User_EPROM_Image_File="True" EPROM_Image_File="">
+      <Application xsi:type="A001_701:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A001_701="http://www.ge.com/CCE/A001_701" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A001_701 A001_701_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Conitel C2020/C2000" Application_Type="DPA" Application_Description="Conitel C2020/C2000 protocol configuration." Application_Identifier="A001" Application_Version="701" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A001_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record Port="COM1" Pre-Transmit_x0020_Delay="15" Post-Transmit_x0020_Delay="5" Communication_x0020_Timeout="60000" Com._x0020_Failure_x0020_Control="(______) Undefined" Host_x0020_Baud_x0020_Rate="1200" Protocol="CONITEL 2000" Number_x0020_of_x0020_LRUs="1" First_x0020_LRU="1" />
+        </A001_COM>
+        <A001XREF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross-Reference">
+          <Record LRU_x0020_Address="1" LRU_x0020_Position="1" />
+        </A001XREF>
+        <A001_LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration">
+          <Record Control_x0020_Time_x0020_Out="2000" SBO_x0020_ENABLE_x0020_Error="Reply" SBO_x0020_Group_x0020_verify="No Check" SBO_x0020_Modifier_x0020_verify="No Check" BCH_x0020_Error_x0020_Window_x0020_Size="10" BCH_x0020_Error_x0020_Threshold="3" Analog_x0020_Setpoint_x0020_Backup="No" Digital_x0020_Setpoint_x0020_Backup="No" Freeze_x0020_Interval="0" Local_x002F_Remote_x0020_Status="(______) Undefined" Local_x0020_Mode_x0020_State="OFF" Bypass_x0020_Control_x0020_Type="TRIP/CLOSE" Bypass_x0020_Control_x0020_Group="0" Bypass_x0020_Control_x0020_Point="0" Offline_x0020_Digital_x0020_Report="Zero" Offline_x0020_Analog_x0020_Report="Zero" Offline_x0020_Accum_x0020_Report="Zero">
+            <Function_x0020_Codes>
+              <Record FC_x0020_0="SCAN" FC_x0020_1="EXECUTE" FC_x0020_2="TRIP SBO" FC_x0020_3="SETPOINT A SBO" FC_x0020_4="CLOSE SBO" FC_x0020_5="SETPOINT B SBO" FC_x0020_6="SETPOINT A DIRECT" FC_x0020_7="SETPOINT B DIRECT" FC_x0020_8="RESET CONTROLS" FC_x0020_9="NOT USED" FC_x0020_A="NOT USED" FC_x0020_B="NOT USED" FC_x0020_C="RTU STATUS" FC_x0020_D="RAISE/LOWER CONTROL" FC_x0020_E="FREEZE COUNTERS" FC_x0020_F="FREEZE &amp; RESET COUNT" />
+            </Function_x0020_Codes>
+            <Scan_x0020_Group>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+              <Record C2000_x0020_Type="NORMAL SCAN" Scan_x0020_Sections="0" Trip_x002F_Close_x0020_Outputs="0" First_x0020_Trip_x002F_Close_x0020_Point="Not Used" Raise_x002F_Lower_x0020_Outputs="0" First_x0020_Raise_x002F_Lower_x0020_Point="Not Used" Setpoint_x0020_A_x0020_Position="Not Used" Setpoint_x0020_B_x0020_Position="Not Used">
+                <Section>
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                  <Record Type="Spare" First_x0020_Point="0" />
+                </Section>
+              </Record>
+            </Scan_x0020_Group>
+          </Record>
+        </A001_LRU>
+        <A001MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Binary Input Map">
+          <Record Type="System Point" System_x002F_Reserved_x0020_Point="(______) Undefined">
+            <Processing_x0020_Options>
+              <Record Input_x0020_Polarity="Normal" COS_x0020_Processing="Yes" MCD_x0020_Processing="None" />
+            </Processing_x0020_Options>
+          </Record>
+        </A001MT01>
+        <A001MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Counter Map">
+          <Record Counter_x0020_Point="0" Processing_x0020_Option="Transition Counting" Freeze_x002F_Clear_x0020_Ownership="No Ownership" />
+        </A001MT03>
+        <A001MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map">
+          <Record Analog_x0020_Input_x0020_Point="(______) Undefined" Divisor="32767" Range="2000" Offset="0" />
+        </A001MT04>
+        <A001MTRL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Raise/Lower Control Map">
+          <Record Raise_x002F_Lower_x0020_Type="Variable Duration" Raise_x0020_Point="(______) Undefined" Raise_x0020_Base="0" Raise_x0020_Increment="0" Lower_x0020_Point="(______) Undefined" Lower_x0020_Base="0" Lower_x0020_Increment="0" />
+        </A001MTRL>
+        <A001MTSP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Setpoint Output Map">
+          <Record Type="Analog Setpoint" Analog_x002F_Digital_x0020_Output_x0020_1="0" Range_x002F_Digital_x0020_Output_x0020_2="0" Divider_x002F_Digital_x0020_Output_x0020_3="0" Offset_x002F_Digital_x0020_Output_x0020_4="0" Digital_x0020_Output_x0020_5="0" Digital_x0020_Output_x0020_6="0" Digital_x0020_Output_x0020_7="0" Digital_x0020_Output_x0020_8="0" Digital_x0020_Output_x0020_9="0" Digital_x0020_Output_x0020_10="0" Digital_x0020_Output_x0020_11="0" Digital_x0020_Output_x0020_12="0" />
+        </A001MTSP>
+        <A001MTTC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Trip/Close Control Map">
+          <Record Digital_x0020_Output_x0020_Point="(______) Undefined" Contact_x0020_Duration="100" />
+        </A001MTTC>
+      </Application>
+      <Application xsi:type="A004-1_303:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A004-1_303="http://www.ge.com/CCE/A004-1_303" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A004-1_303 A004-1_303_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="TRW S-9000" Application_Type="DPA" Application_Description="TRW S-9000 DPA Configuration" Application_Identifier="A004-1" Application_Version="303" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A004_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration" />
+        <A004LRXF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross-Reference" />
+        <A004_LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration" />
+        <A004_DAP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DAP Configuration" />
+        <A00430SE Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="30-Sec Analog Input Map">
+          <Record Analog_x0020_Input_x0020_Point="0" Range="4095" Divider="65535" Offset="2048" Input_x0020_Polarity="Bipolar" />
+        </A00430SE>
+        <A0043SEC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="3-Sec Analog Input Map">
+          <Record Analog_x0020_Input_x0020_Point="0" Range="4095" Divider="65535" Offset="2048" Input_x0020_Polarity="Bipolar" />
+        </A0043SEC>
+        <A004MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status Input Map" />
+        <A004MT02 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Output Map" />
+        <A004MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Counter Map" />
+        <A004MT05 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Setpoint Map" />
+      </Application>
+      <Application xsi:type="A016-0_200:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A016-0_200="http://www.ge.com/CCE/A016-0_200" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A016-0_200 A016-0_200_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Conitel 3000 Protocol" Application_Type="DPA" Application_Description="Conitel 3000 communications protocol" Application_Identifier="A016-0" Application_Version="200" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A016_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Comm Port Parameters">
+          <Record Port_x0020_ID="COM1" Baud_x0020_Rate="9600" Pre-Tx_x0020_Char="4" Post-Tx_x0020_Char="1" TPTM_x0020_Bias="0" TRX_x0020_Bias="0" Comm_x0020_Fail_x0020_Output_x0020_Point="(______) Undefined" Comm_x0020_Fail_x0020_Timer="60" LRU_x0020_Offset="1" Total_x0020_LRUs="1" />
+        </A016_COM>
+        <A016_XRF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross Reference">
+          <Record LRU_x0020_Address="1" LRU_x0020_Offset="1" />
+        </A016_XRF>
+        <A016_LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Parameters">
+          <Record Local_x002F_Remote_x0020_Input="(______) Undefined" Local_x002F_Remote_x0020_State="0" Accum._x0020_Freeze_x0020_Output="(______) Undefined" Accum_x0020_Freeze_x0020_Time="3000" T_x002F_C_x0020_Select_x0020_Timeout="30" Number_x0020_of_x0020_SOEs="100" Group_x0020_Offset="1" Group_x0020_Count="0" SOE_x0020_methods="Time Correlated" />
+        </A016_LRU>
+        <A016_GRP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Conitel Group Definition">
+          <Record Group_x0020_Number="0" Scan_x0020_Offset="1" Scan_x0020_Count="0" T_x002F_C_x0020_Offset="1" T_x002F_C_x0020_Count="0" R_x002F_L_x0020_Offset="1" R_x002F_L_x0020_Count="0" Set_x0020_Point_x0020_Offset="1" Set_x0020_Point_x0020_Count="0" />
+        </A016_GRP>
+        <A016_RL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Raise/Lower Control Map">
+          <Record Raise_x0020_DO_x0020_Point="(______) Undefined" Raise_x0020_Base_x0020_Duration="0" Raise_x0020_Inc._x0020_Duration="1" Lower_x0020_DO_x0020_Point="(______) Undefined" Lower_x0020_Base_x0020_Duration="0" Lower_x0020_Inc._x0020_Duration="1" />
+        </A016_RL>
+        <A016_SP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Set Point Map">
+          <Record System_x0020_Point="0" Options="AO: 2's Complement" Range="32767" Divisor="2047" Offset="0" DO_x0020_Operate_x0020_Time="500" DO_x0020_Delay_x0020_Time="50" />
+        </A016_SP>
+        <A016_TC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Trip/Close Control Map">
+          <Record DO_x0020_Point="(______) Undefined" Trip_x0020_Duration="1" Close_x0020_Duration="1" Operation_x0020_Mode="T/C" />
+        </A016_TC>
+        <A016SCAN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Conitel Scan Definitions">
+          <Record Section_x0020_Type="MCD Status Data" Table_x0020_Offset="1" />
+        </A016SCAN>
+        <A016_ACC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator Map">
+          <Record Acc_x0020_Point="0">
+            <Options>
+              <Record Type="12 Bit Accumulator" Freeze_x0020_Enable="No" Freeze-Reset_x0020_Enable="No" Counting_x0020_Method="Transition" Counter_x0020_Source="Frozen Buffer" />
+            </Options>
+          </Record>
+        </A016_ACC>
+        <A016_AI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map">
+          <Record Analog_x0020_Input_x0020_Point="(______) Undefined" Conversion_x0020_Mode="Bipolar 2's complement" Range="2047" Divisor="32767" Offset="0" Dead_x0020_Band="1" Alarm_x0020_Limit="2000" />
+        </A016_AI>
+        <A016_DI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Map">
+          <Record DI_x0020_Point="(______) Undefined">
+            <Options>
+              <Record Invert="No" SOE_x0020_Enable="No" />
+            </Options>
+          </Record>
+        </A016_DI>
+      </Application>
+      <Application xsi:type="A017_131:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A017_131="http://www.ge.com/CCE/A017_131" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A017_131 A017_131_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="DNP V1.00" Application_Type="DTA" Application_Description="Distributed Network Protocol (part of the Mascom System)." Application_Identifier="A017" Application_Version="131" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A017LUNS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LUN Translation">
+          <Record />
+        </A017LUNS>
+        <CFG_A017 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record />
+        </CFG_A017>
+      </Application>
+      <Application xsi:type="A018_120:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A018_120="http://www.ge.com/CCE/A018_120" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A018_120 A018_120_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Quantum Meter Scanner" Application_Type="DCA" Application_Description="Quantum Meter Scanner" Application_Identifier="A018" Application_Version="120" Application_Revision="0" DCA_Index="8" Enabled="False">
+        <A018_WIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Parameters">
+          <Record DCA_x0020_Index="8" />
+        </A018_WIN>
+        <A018COMP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Meter Computation" />
+        <A018CONV Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Data Type Translation">
+          <Record />
+        </A018CONV>
+        <A018MBP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Meter Raw and Base Page">
+          <Record />
+        </A018MBP>
+        <A018MDEF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Meter Definition">
+          <Record />
+        </A018MDEF>
+        <A018STAT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Meter Status Translation">
+          <Record DCA_x0020_Point="(______) Undefined" />
+        </A018STAT>
+      </Application>
+      <Application xsi:type="A020_421:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A020_421="http://www.ge.com/CCE/A020_421" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A020_421 A020_421_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="HR6000 DCA" Application_Type="DCA" Application_Description="HR6000 DCA protocol." Application_Identifier="A020" Application_Version="421" Application_Revision="0" DCA_Index="9" Enabled="False">
+        <A020_RL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="R/L Table" />
+        <A020_SRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="SRU Table">
+          <Record />
+        </A020_SRU>
+        <A020APPL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Main Table">
+          <Record />
+        </A020APPL>
+        <A020DATA Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Data Port Table">
+          <Record />
+        </A020DATA>
+        <A020PORT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Table">
+          <Record />
+        </A020PORT>
+      </Application>
+      <Application xsi:type="A022_203:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A022_203="http://www.ge.com/CCE/A022_203" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A022_203 A022_203_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="SC 1801 DPA" Application_Type="DPA" Application_Description="SC 1801 DPA configuration table." Application_Identifier="A022" Application_Version="203" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <CFG_A022 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration" />
+        <LRU_A022 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration" />
+        <MT1_A022 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status Input Map" />
+        <MT2_A022 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Output Map" />
+        <MT3_A022 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator Map" />
+        <MT4_A022 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map" />
+        <MT5_A022 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+      </Application>
+      <Application xsi:type="A025_302:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A025_302="http://www.ge.com/CCE/A025_302" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A025_302 A025_302_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Conitel C0300" Application_Type="DPA" Application_Description="Conitel C0300 protocol configuration." Application_Identifier="A025" Application_Version="302" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A025_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration" />
+        <A025XREF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross-Reference" />
+        <A025_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration" />
+        <A025MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Map" />
+        <A025MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Counter Map" />
+        <A025MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map" />
+        <A025MTRL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Raise/Lower Control Map" />
+        <A025MTSP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Setpoint Output Map" />
+        <A025MTTC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Trip/Close Control Map" />
+      </Application>
+      <Application xsi:type="A026-1_321:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A026-1_321="http://www.ge.com/CCE/A026-1_321" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A026-1_321 A026-1_321_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Communication Watchdog" Application_Type="DTA" Application_Description="Reports on the state of communications between the RTU and a remote device." Application_Identifier="A026-1" Application_Version="321" Application_Revision="0" DCA_Index="1" Enabled="True">
+        <A026_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Communication Events">
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="134" Normal_x0020_State="Off" Start_x0020_Point="1" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="DI Point On/Off-line" Status_x0020_Point="135" Normal_x0020_State="Off" Start_x0020_Point="1" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="DI Point On/Off-line" Status_x0020_Point="136" Normal_x0020_State="Off" Start_x0020_Point="65" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="DO Point On/Off-line" Status_x0020_Point="137" Normal_x0020_State="Off" Start_x0020_Point="1" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="DO Point On/Off-line" Status_x0020_Point="138" Normal_x0020_State="Off" Start_x0020_Point="33" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="139" Normal_x0020_State="Off" Start_x0020_Point="52" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="140" Normal_x0020_State="Off" Start_x0020_Point="81" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="141" Normal_x0020_State="Off" Start_x0020_Point="110" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="142" Normal_x0020_State="Off" Start_x0020_Point="139" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="143" Normal_x0020_State="Off" Start_x0020_Point="168" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="144" Normal_x0020_State="Off" Start_x0020_Point="197" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="145" Normal_x0020_State="Off" Start_x0020_Point="226" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="146" Normal_x0020_State="Off" Start_x0020_Point="240" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="Comm. Fail/Restore" Status_x0020_Point="147" Normal_x0020_State="Off" Start_x0020_Point="14" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="148" Normal_x0020_State="Off" Start_x0020_Point="267" Number_x0020_of_x0020_Devices="1" />
+          <Record Operating_x0020_Condition="OR" Channel_x002F_Type_x0020_Specifier="AI Point On/Off-line" Status_x0020_Point="149" Normal_x0020_State="Off" Start_x0020_Point="266" Number_x0020_of_x0020_Devices="1" />
+        </A026_CFG>
+        <A026_DCA Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Configuration">
+          <Record DCA_x0020_Index="1" />
+        </A026_DCA>
+      </Application>
+      <Application xsi:type="A027_810:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A027_810="http://www.ge.com/CCE/A027_810" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A027_810 A027_810_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="SOE Logger DTA" Application_Type="DTA" Application_Description="SOE Logger DTA configuration." Application_Identifier="A027" Application_Version="810" Application_Revision="0" DCA_Index="10" Enabled="False">
+        <A027MAIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Configuration">
+          <Record />
+        </A027MAIN>
+        <A027LOG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Logger Configuration">
+          <Record>
+            <Baud_x0020_Rate>
+              <Record />
+            </Baud_x0020_Rate>
+            <Port_x0020_Configuration>
+              <Record />
+            </Port_x0020_Configuration>
+            <Analog_x0020_SOE_x0020_Logging>
+              <Record />
+            </Analog_x0020_SOE_x0020_Logging>
+            <Digital_x0020_SOE_x0020_Logging>
+              <Record />
+            </Digital_x0020_SOE_x0020_Logging>
+            <Data_x0020_Description>
+              <Record />
+            </Data_x0020_Description>
+          </Record>
+        </A027LOG>
+        <A027MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Mapping">
+          <Record Digital_x0020_Input_x0020_Point="(______) Undefined" />
+        </A027MT01>
+        <A027MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Mapping">
+          <Record Analog_x0020_Input_x0020_Point="(______) Undefined" />
+        </A027MT04>
+      </Application>
+      <Application xsi:type="A029_707:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A029_707="http://www.ge.com/CCE/A029_707" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A029_707 A029_707_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="CDC Type II" Application_Type="DPA" Application_Description="CDC Type II DPA Configuration" Application_Identifier="A029" Application_Version="707" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A029_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record RTS_x0020_On_x0020_Delay="20" RTS_x0020_Off_x0020_Delay="20" Char-Char_x0020_Timeout="30" Communication_x0020_Timeout="60000" Comm_x0020_Fail_x0020_Control="(______) Undefined" Comm_x0020_Fail_x0020_Duration="20" Baud_x0020_Rate="1200" Stop_x0020_Bits="ONE STOP BIT" Parity="None" Number_x0020_of_x0020_LRUs="1" First_x0020_LRU="1" Com_x0020_Port="COM1" Filler="" Future_x0020_Use="" />
+        </A029_CFG>
+        <A029_LXR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross Reference">
+          <Record RTU_x0020_Address="3" First_x0020_LRU="1" />
+        </A029_LXR>
+        <A029_LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration">
+          <Record First_x0020_Status_x002F_SOE_x0020_Point="0" _x0023__x0020_of_x0020_Status_x002F_SOE_x0020_Points="64" First_x0020_Trip_x002F_Close_x0020_Point="0" _x0023__x0020_of_x0020_Trip_x002F_Close_x0020_Points="24" First_x0020_Raise_x002F_Lower_x0020_Point="0" _x0023__x0020_of_x0020_Raise_x002F_Lower_x0020_Points="0" First_x0020_Accumulator_x0020_Point="0" _x0023__x0020_of_x0020_Accumulator_x0020_Points="0" First_x0020_Analog_x0020_Input_x0020_Point="0" _x0023__x0020_of_x0020_Analog_x0020_Input_x0020_Points="36" First_x0020_Analog_x0020_Output_x0020_Pnt="0" _x0023__x0020_of_x0020_Analog_x0020_Output_x0020_Pnts="0" First_x0020_Control_x0020_Allow="0" Number_x0020_of_x0020_Control_x0020_Allow="0" Control_x0020_Timeout="5000" SOE_x0020_Buffer_x0020_Size="400" SOE_x0020_Overflow_x0020_Flag="Preserve Newest Events" SOE_x0020_Buffer_x0020_Location="RAM" SOE_x0020_Holdoff_x0020_Time="0" Analog_x0020_Output_x0020_Size="10 Bits" MCD_x0020_Edge_x0020_Type="0-&gt;1&amp;1-&gt;0 (1-Bit Change)" RTU_STS_x0020_En_x002F_Disable_x0020_COMM="Enable ALL Sources" Future_x0020_Use="">
+            <RTU_x0020_Status_x0020_Enable>
+              <Record>
+                <RTU_x0020_Status_x0020_Mask>
+                  <Record Initialization="Enable" SOE_x0020_Error="Enable" SOE_x0020_Data="Enable" More_x0020_SOE_x0020_Data="Enable" Comm_x0020_Fail_x0020_Detected="Disable" All_x0020_Station="Enable" />
+                </RTU_x0020_Status_x0020_Mask>
+              </Record>
+            </RTU_x0020_Status_x0020_Enable>
+          </Record>
+        </A029_LRU>
+        <A029CTAL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Allow Map" />
+        <A029MC01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Trip/Close Control Map">
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="1000" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="1000" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+          <Record Control_x0020_Point="0" Control_x0020_Duration="500" />
+        </A029MC01>
+        <A029MC02 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Raise/Lower Map" />
+        <A029MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status/SOE Map">
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="1" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="2" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="3" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="4" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="5" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="6" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="7" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="8" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="9" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="10" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="16" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="17" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="18" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="19" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="31" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="2 Bit MCD" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="11" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="0" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="12" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="13" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="14" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="15" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="20" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="21" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="22" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="23" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="24" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="25" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="26" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="27" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="28" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="29" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="155" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="154" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="30" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="32" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="33" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="34" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="35" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="36" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="37" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="38" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="39" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="40" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="41" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="42" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="43" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="44" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="45" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+          <Record Status_x0020_Input_x0020_Point="46" Filler="">
+            <Flags>
+              <Record Status_x0020_Input_x0020_Type="Simple Status" SOE_x0020_Enable="Enabled" Status_x0020_Invert="Normal" />
+            </Flags>
+          </Record>
+        </A029MT01>
+        <A029MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator Map" />
+        <A029MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map">
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="52" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="53" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="36" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="37" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="38" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="81" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="82" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="65" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="66" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="67" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+          <Record Analog_x0020_Input_x0020_Point="0" Range="2032" Divider="32767" Offset="0" Input_x0020_Type="Bipolar" />
+        </A029MT04>
+        <A029MT05 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+      </Application>
+      <Application xsi:type="A030_300:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A030_300="http://www.ge.com/CCE/A030_300" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A030_300 A030_300_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Accumulator Freeze" Application_Type="DTA" Application_Description="Detects system status point changes and system accumulator point freezes." Application_Identifier="A030" Application_Version="300" Application_Revision="0" DCA_Index="11" Enabled="False">
+        <A030CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DTA Misc Parameters">
+          <Record DCA_x0020_Index="11" />
+        </A030CFG>
+        <A030_ACC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Timed Freeze ACC mapping" />
+        <A030CFG1 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status/ACC Freeze" />
+        <A030CFG2 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="ACC Freeze/Controls" />
+        <A030CFG3 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Timed ACC Freeze" />
+      </Application>
+      <Application xsi:type="A031_310:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A031_310="http://www.ge.com/CCE/A031_310" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A031_310 A031_310_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="TRW 9550" Application_Type="DPA" Application_Description="TRW 9550 protocol." Application_Identifier="A031" Application_Version="310" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A031_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration" />
+        <A031LRXF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross-Reference" />
+        <A031_LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration" />
+        <A031MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status Input Map" />
+        <A031MT02 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Output Map" />
+        <A031MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Counter Map" />
+        <A031MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map" />
+        <A031MT05 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+        <A031MTRL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Raise/Lower Control Map" />
+      </Application>
+      <Application xsi:type="A035_211:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A035_211="http://www.ge.com/CCE/A035_211" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A035_211 A035_211_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Analog Reference" Application_Type="DTA" Application_Description="Analog reference check DTA." Application_Identifier="A035" Application_Version="211" Application_Revision="0" DCA_Index="12" Enabled="False">
+        <A035CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Reference" />
+        <A035DCA Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Parameters">
+          <Record />
+        </A035DCA>
+      </Application>
+      <Application xsi:type="A036_421:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A036_421="http://www.ge.com/CCE/A036_421" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A036_421 A036_421_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="ProLogic Executor" Application_Type="DTA" Application_Description="ProLogic Executor" Application_Identifier="A036" Application_Version="421" Application_Revision="0" DCA_Index="13" Enabled="False">
+        <A036_ADR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Address Registers">
+          <Record />
+        </A036_ADR>
+        <A036_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Executor Configuration">
+          <Record />
+        </A036_COM>
+        <A036_CPR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Counter Presets">
+          <Record />
+        </A036_CPR>
+        <A036_CVL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Counter Values">
+          <Record />
+        </A036_CVL>
+        <A036_FLG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Flag States">
+          <Record>
+            <Flag_x0020_States_x0020__x0028_1_x0020_-_x0020_16_x0029_>
+              <Record />
+            </Flag_x0020_States_x0020__x0028_1_x0020_-_x0020_16_x0029_>
+            <Flag_x0020_States_x0020__x0028_17_x0020_-_x0020_32_x0029_>
+              <Record />
+            </Flag_x0020_States_x0020__x0028_17_x0020_-_x0020_32_x0029_>
+          </Record>
+        </A036_FLG>
+        <A036_LTH Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Latch States">
+          <Record>
+            <Latch_x0020_States_x0020__x0028_1_x0020_-_x0020_16_x0029_>
+              <Record />
+            </Latch_x0020_States_x0020__x0028_1_x0020_-_x0020_16_x0029_>
+            <Latch_x0020_States_x0020__x0028_17_x0020_-_x0020_32_x0029_>
+              <Record />
+            </Latch_x0020_States_x0020__x0028_17_x0020_-_x0020_32_x0029_>
+          </Record>
+        </A036_LTH>
+        <A036_PRG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Program Instructions">
+          <Record />
+        </A036_PRG>
+        <A036_REG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Register Values">
+          <Record />
+        </A036_REG>
+        <A036_TC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Type">
+          <Record />
+        </A036_TC>
+        <A036_TMR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Timer Type">
+          <Record>
+            <Type_x0020_And_x0020_Time_x0020_Base>
+              <Record />
+            </Type_x0020_And_x0020_Time_x0020_Base>
+          </Record>
+        </A036_TMR>
+        <A036_TPR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Timer Presets">
+          <Record />
+        </A036_TPR>
+        <A036_TVL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Timer Values">
+          <Record />
+        </A036_TVL>
+        <A036MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status Map">
+          <Record Status_x0020_point="(______) Undefined" />
+        </A036MT01>
+        <A036MT02 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Map">
+          <Record Control_x0020_Point="(______) Undefined" />
+        </A036MT02>
+        <A036MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator Map">
+          <Record Accumulator_x0020_Point="0" />
+        </A036MT03>
+        <A036MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map">
+          <Record Analog_x0020_Input_x0020_Point="(______) Undefined" />
+        </A036MT04>
+        <A036MT05 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map">
+          <Record Setpoint="0" />
+        </A036MT05>
+      </Application>
+      <Application xsi:type="A059_902:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A059_902="http://www.ge.com/CCE/A059_902" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A059_902 A059_902_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Modbus DCA" Application_Type="DCA" Application_Description="Modbus Data Collection Application" Application_Identifier="A059" Application_Version="902" Application_Revision="0" DCA_Index="14" Enabled="False">
+        <A059_VC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Virtual Connection">
+          <Record>
+            <Esc_x0020_Seq>
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+              <Record />
+            </Esc_x0020_Seq>
+          </Record>
+        </A059_VC>
+        <A059COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Communication Port">
+          <Record />
+        </A059COM>
+        <A059CTL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Sets" />
+        <A059MAIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Main Application">
+          <Record />
+        </A059MAIN>
+        <A059REG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Register Sets" />
+        <A059SPT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Setpoint Sets" />
+        <A059SRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="SRU Configuration">
+          <Record>
+            <Control_x0020_Feedback_x0020_Poll>
+              <Record />
+            </Control_x0020_Feedback_x0020_Poll>
+            <Setpoint_x0020_Feedback_x0020_Poll>
+              <Record />
+            </Setpoint_x0020_Feedback_x0020_Poll>
+          </Record>
+        </A059SRU>
+        <A059STS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status Sets" />
+      </Application>
+      <Application xsi:type="A068_229:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A068_229="http://www.ge.com/CCE/A068_229" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A068_229 A068_229_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Modbus DPA" Application_Type="DPA" Application_Description="Modbus DPA Configuration" Application_Identifier="A068" Application_Version="229" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A068COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration" />
+        <A068XRF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross-Reference" />
+        <A068LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration" />
+        <A068REG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Register Set" />
+        <A068STS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status Set" />
+        <A068_AI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map" />
+        <A068_AO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+        <A068_DI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Map" />
+        <A068_DO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Output Map" />
+      </Application>
+      <Application xsi:type="A078_609:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A078_609="http://www.ge.com/CCE/A078_609" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A078_609 A078_609_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="SEL Gateway DCA" Application_Type="DCA" Application_Description="SEL relay data collection application." Application_Identifier="A078" Application_Version="609" Application_Revision="0" DCA_Index="15" Enabled="False">
+        <A078_RLY Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Relay Configuration">
+          <Record />
+        </A078_RLY>
+        <A078_TGT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Target Configuration" />
+        <A078MAIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="General Information">
+          <Record />
+        </A078MAIN>
+        <A078PORT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record />
+        </A078PORT>
+      </Application>
+      <Application xsi:type="A083-0_335:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A083-0_335="http://www.ge.com/CCE/A083-0_335" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A083-0_335 A083-0_335_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Calculator DTA" Application_Type="DTA" Application_Description="Controls digital and analog inputs and outputs  using ASCII expressions" Application_Identifier="A083-0" Application_Version="335" Application_Revision="0" DCA_Index="2" Enabled="True">
+        <A083ACMP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator Map" />
+        <A083AIEX Table_Enabled="False" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Inputs" />
+        <A083AIMP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map" />
+        <A083AOMP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+        <A083APPL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="General Information">
+          <Record DCA_x0020_index="2" Diagnostic_x0020_Level="Level 0" Priority="Normal" Update_x0020_Interval="500" Output_x0020_Response_x0020_Wait="Yes" Send_x0020_Offline="No" Data_x0020_Change_x0020_Time_x0020_Tag="Post-evaluation" />
+        </A083APPL>
+        <A083DIEX Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Inputs">
+          <Record Expression="DI1||DI2||DI3||DI4||DI5" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="DI6||DI7||DI8||DI9||DI10||DI11||DI12||DI13||DI14" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="DI15||DI16" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="DI17||DI18||DI19||DI21" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="DI20" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+          <Record Expression="" NULL="" Event_x0020_Types="Both" />
+        </A083DIEX>
+        <A083DIMP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Map">
+          <Record Point="134" />
+          <Record Point="135" />
+          <Record Point="136" />
+          <Record Point="137" />
+          <Record Point="138" />
+          <Record Point="139" />
+          <Record Point="140" />
+          <Record Point="141" />
+          <Record Point="142" />
+          <Record Point="143" />
+          <Record Point="144" />
+          <Record Point="145" />
+          <Record Point="146" />
+          <Record Point="147" />
+          <Record Point="148" />
+          <Record Point="149" />
+          <Record Point="58" />
+          <Record Point="59" />
+          <Record Point="62" />
+          <Record Point="61" />
+          <Record Point="44" />
+        </A083DIMP>
+        <A083DOEX Table_Enabled="False" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Outputs" />
+        <A083DOMP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Output Map" />
+        <A083OREX Table_Enabled="False" Table_Modified_Date="" Table_Default_Config="" Table_Name="Output Request" />
+        <A083STTM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Storage Timers" />
+        <A083TIME Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Non-Storage Timers" />
+      </Application>
+      <Application xsi:type="A092-0_103:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A092-0_103="http://www.ge.com/CCE/A092-0_103" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A092-0_103 A092-0_103_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="DPU DCA" Application_Type="DCA" Application_Description="Distributiom Protection Unit DCA" Application_Identifier="A092-0" Application_Version="103" Application_Revision="0" DCA_Index="16" Enabled="False">
+        <A092_DPU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DPU Table">
+          <Record />
+        </A092_DPU>
+        <A092MAIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Main">
+          <Record />
+        </A092MAIN>
+        <A092PORT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Table">
+          <Record />
+        </A092PORT>
+      </Application>
+      <Application xsi:type="A185-0_200:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A185-0_200="http://www.ge.com/CCE/A185-0_200" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A185-0_200 A185-0_200_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="W18979 DPA" Application_Type="DPA" Application_Description="Landis and Gyr 8979." Application_Identifier="A185-0" Application_Version="200" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A185_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Communication Port" />
+        <A185_LXR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross-Reference" />
+        <A185_LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration" />
+        <A185MSOE Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="SOE Map" />
+        <A185MT00 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Indication Map" />
+        <A185MT02 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="SBO Control Map" />
+        <A185MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator Map" />
+        <A185MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map" />
+        <A185MT05 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+        <A185MT11 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Reference Map" />
+        <A185MTDI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Word Map" />
+        <A185MTRL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Pulse Control Map" />
+        <A185MTSP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Output Word Map" />
+        <A185CHAS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Chassis Configuration" />
+      </Application>
+      <Application xsi:type="A194-0_100:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A194-0_100="http://www.ge.com/CCE/A194-0_100" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A194-0_100 A194-0_100_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Cooper 2179 DCA" Application_Type="DCA" Application_Description="Cooper 2179 DCA, continue from A039 v901" Application_Identifier="A194-0" Application_Version="100" Application_Revision="0" DCA_Index="17" Enabled="False">
+        <A194_ORD Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Ordinal Table">
+          <Record />
+        </A194_ORD>
+        <A194APPL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="General Parameters">
+          <Record />
+        </A194APPL>
+        <A194DVCF Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DVCF Table" />
+        <A194MODE Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Mode Download Pseudo DO" />
+        <A194PORT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record />
+        </A194PORT>
+        <A194UNIT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Unit Configuration">
+          <Record />
+        </A194UNIT>
+      </Application>
+      <Application xsi:type="A199-0_103:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:A199-0_103="http://www.ge.com/CCE/A199-0_103" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/A199-0_103 A199-0_103_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="HR6000/XA-21" Application_Type="DPA" Application_Description="Harris HR6000/XA-21 protocol." Application_Identifier="A199-0" Application_Version="103" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <A199_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration" />
+        <A199_LXR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Cross-Reference" />
+        <A199_LRU Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LRU Configuration" />
+        <A199_PRT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Harris Port Config" />
+        <A199CAKT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Allow Map" />
+        <A199MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Map" />
+        <A199MT02 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Output Map" />
+        <A199MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator Map" />
+        <A199MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map" />
+        <A199MT05 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+        <A199DEVT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Map" />
+      </Application>
+      <Application xsi:type="B003_749:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B003_749="http://www.ge.com/CCE/B003_749" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B003_749 B003_749_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="D.20 Peripheral Link" Application_Type="DCA" Application_Description="D.20 peripheral interface." Application_Identifier="B003" Application_Version="749" Application_Revision="0" DCA_Index="0" Enabled="True">
+        <B003_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Communication Parameters">
+          <Record DCA_x0020_Index_x0020_Field="0" Debug="0" Flags="0" Net_x0020_Wait="5" Net_x0020_Retries="3" Global_x0020_Message_x0020_Delay="10" Priority_00="2000" Priority_0A="4000" Priority_11="60000" SOE_x0020_Buffer_x0020_Size="10" MAX_x0020_Restart_x0020_Time="300" Acceleration_x0020_Factor="10" Max_polls_x0020__x002F__x0020_Retries="65541" Reserved1="0" Reserved2="0" Reserved3="0" Reserved4="0" Reserved5="0" />
+        </B003_CFG>
+        <B003AIEX Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Scale">
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+          <Record Flag="0" D20M_x0020_High_x0020_Scale="100" D20M_x0020_Low_x0020_Scale="-100" Peripheral_x0020_High_x0020_Scale="100" Peripheral_x0020_Low_x0020_Scale="-100" Reserved_x0020_1="0" Reserved_x0020_2="0" />
+        </B003AIEX>
+        <B003DOEX Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Output Resetting">
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+          <Record Flag="0" Reserved="0" />
+        </B003DOEX>
+        <B045SCAL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="AC Board Scaling">
+          <Record />
+        </B045SCAL>
+        <D20_CNFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="D20 Configuration">
+          <Record DEV_NUM="1" Priority="1" NUM_00="0" NUM_01="0" NUM_03="0" NUM_06="0" NUM_0A="32" NUM_11="8" NUM_80="0" NUM_81="0" NUM_82="1" NUM_A0="0" P_CODE_NAME="D20AEXEC" P_DATA_NAME="S033CFG" P_DATA_OFFSET="0" Pa_offset="0" />
+          <Record DEV_NUM="2" Priority="1" NUM_00="64" NUM_01="64" NUM_03="64" NUM_06="0" NUM_0A="0" NUM_11="0" NUM_80="0" NUM_81="0" NUM_82="2" NUM_A0="0" P_CODE_NAME="D20SEXEC" P_DATA_NAME="S032CFG" P_DATA_OFFSET="0" Pa_offset="66" />
+          <Record DEV_NUM="3" Priority="1" NUM_00="64" NUM_01="64" NUM_03="64" NUM_06="0" NUM_0A="0" NUM_11="0" NUM_80="0" NUM_81="0" NUM_82="2" NUM_A0="0" P_CODE_NAME="D20SEXEC" P_DATA_NAME="S032CFG" P_DATA_OFFSET="1" Pa_offset="66" />
+          <Record DEV_NUM="4" Priority="1" NUM_00="0" NUM_01="0" NUM_03="0" NUM_06="0" NUM_0A="0" NUM_11="0" NUM_80="32" NUM_81="0" NUM_82="3" NUM_A0="0" P_CODE_NAME="D20KEXEC" P_DATA_NAME="S034CFG" P_DATA_OFFSET="0" Pa_offset="0" />
+          <Record DEV_NUM="5" Priority="1" NUM_00="0" NUM_01="0" NUM_03="0" NUM_06="0" NUM_0A="0" NUM_11="0" NUM_80="32" NUM_81="0" NUM_82="3" NUM_A0="0" P_CODE_NAME="D20KEXEC" P_DATA_NAME="S034CFG" P_DATA_OFFSET="1" Pa_offset="0" />
+        </D20_CNFG>
+        <DNETCNFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Network Parameters">
+          <Record Timeout="0" Retries="0" Filler="0" Address="0" />
+          <Record Timeout="21" Retries="3" Filler="0" Address="2" />
+          <Record Timeout="21" Retries="3" Filler="0" Address="4" />
+          <Record Timeout="21" Retries="3" Filler="0" Address="6" />
+          <Record Timeout="21" Retries="3" Filler="0" Address="8" />
+          <Record Timeout="21" Retries="3" Filler="0" Address="10" />
+        </DNETCNFG>
+        <S032CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="S Board Configuration">
+          <Record S_x0020_board_x0020_binary="0978010204081020408001020408102040800102040810204080010204081020408001020408102040800102040810204080010204081020408001020408102040800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" />
+          <Record S_x0020_board_x0020_binary="0978010204081020408001020408102040800102040810204080010204081020408001020408102040800102040810204080010204081020408001020408102040800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" />
+        </S032CFG>
+        <S033CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="A board configuration">
+          <Record A_x0020_binary_x0020_field="05A50100643C01F405050505050505050505050505050505050505050505050505050505050505050404040404040404040404040404040404040404040404040404040404040404000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1FFF000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" />
+        </S033CFG>
+        <S034CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="K Board Configuration">
+          <Record K_x0020_Board_x0020_binary_x0020_data="008200000A0A640A00" />
+          <Record K_x0020_Board_x0020_binary_x0020_data="008200000A0A640A00" />
+        </S034CFG>
+        <S035CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="C Board Configuration">
+          <Record />
+        </S035CFG>
+        <S055CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="AC Board Configuration">
+          <Record />
+        </S055CFG>
+      </Application>
+      <Application xsi:type="B008-1_304:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B008-1_304="http://www.ge.com/CCE/B008-1_304" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B008-1_304 B008-1_304_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="System Point Database" Application_Type="WIN" Application_Description="Maintains the database of system points in the RTU." Application_Identifier="B008-1" Application_Version="304" Application_Revision="0" DCA_Index="7" Enabled="True">
+        <B008_CO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Complex Object List">
+          <Record NumCO="0" Flag="0" Future="0" />
+          <Record NumCO="0" Flag="0" Future="0" />
+          <Record NumCO="0" Flag="0" Future="0" />
+          <Record NumCO="0" Flag="0" Future="0" />
+          <Record NumCO="0" Flag="0" Future="0" />
+          <Record NumCO="0" Flag="0" Future="0" />
+          <Record NumCO="0" Flag="0" Future="0" />
+        </B008_CO>
+        <B008_DCA Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Configuration List">
+          <Record NumDI="128" NumDO="64" NumCT="0" NumAI="32" NumAO="0" NumDV="5" NumCO="0" NumAD="0" Reserve1="0" Reserve2="0" Reserve3="0" Reserve4="0" Reserve5="0" Reserve6="0" Reserve7="0" Reserve8="0" />
+          <Record NumDI="25" NumDO="0" NumCT="0" NumAI="0" NumAO="0" NumDV="0" NumCO="0" NumAD="0" Reserve1="0" Reserve2="0" Reserve3="0" Reserve4="0" Reserve5="0" Reserve6="0" Reserve7="0" Reserve8="0" />
+          <Record NumDI="20" NumDO="0" NumCT="0" NumAI="0" NumAO="0" NumDV="0" NumCO="0" NumAD="0" Reserve1="0" Reserve2="0" Reserve3="0" Reserve4="0" Reserve5="0" Reserve6="0" Reserve7="0" Reserve8="0" />
+          <Record NumDI="51" NumDO="39" NumCT="0" NumAI="87" NumAO="0" NumDV="3" NumCO="0" NumAD="0" Reserve1="0" Reserve2="0" Reserve3="0" Reserve4="0" Reserve5="0" Reserve6="0" Reserve7="0" Reserve8="0" />
+          <Record NumDI="51" NumDO="39" NumCT="0" NumAI="87" NumAO="0" NumDV="3" NumCO="0" NumAD="0" Reserve1="0" Reserve2="0" Reserve3="0" Reserve4="0" Reserve5="0" Reserve6="0" Reserve7="0" Reserve8="0" />
+          <Record NumDI="35" NumDO="29" NumCT="0" NumAI="58" NumAO="0" NumDV="2" NumCO="0" NumAD="0" Reserve1="0" Reserve2="0" Reserve3="0" Reserve4="0" Reserve5="0" Reserve6="0" Reserve7="0" Reserve8="0" />
+          <Record NumDI="19" NumDO="19" NumCT="0" NumAI="8" NumAO="0" NumDV="1" NumCO="0" NumAD="0" Reserve1="0" Reserve2="0" Reserve3="0" Reserve4="0" Reserve5="0" Reserve6="0" Reserve7="0" Reserve8="0" />
+        </B008_DCA>
+        <B008_SUB Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="SubGroup Control Lockout" />
+        <B008LOCK Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Lockout" />
+        <B008TMDO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Time To Live">
+          <Record Holdoff_x0020_Time="0" Time_x0020_To_x0020_Live="0" />
+          <Record Holdoff_x0020_Time="0" Time_x0020_To_x0020_Live="0" />
+          <Record Holdoff_x0020_Time="0" Time_x0020_To_x0020_Live="0" />
+          <Record Holdoff_x0020_Time="0" Time_x0020_To_x0020_Live="0" />
+          <Record Holdoff_x0020_Time="0" Time_x0020_To_x0020_Live="0" />
+          <Record Holdoff_x0020_Time="0" Time_x0020_To_x0020_Live="0" />
+          <Record Holdoff_x0020_Time="0" Time_x0020_To_x0020_Live="0" />
+        </B008TMDO>
+        <CFG_DCA Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Configuration List">
+          <Record DINum="128" NumDO="64" NumCounter="0" NumAI="32" NumAO="0" NumDev="5" SOEFlag="0" />
+          <Record DINum="25" NumDO="0" NumCounter="0" NumAI="0" NumAO="0" NumDev="0" SOEFlag="0" />
+          <Record DINum="20" NumDO="0" NumCounter="0" NumAI="0" NumAO="0" NumDev="0" SOEFlag="0" />
+          <Record DINum="51" NumDO="39" NumCounter="0" NumAI="87" NumAO="0" NumDev="3" SOEFlag="0" />
+          <Record DINum="51" NumDO="39" NumCounter="0" NumAI="87" NumAO="0" NumDev="3" SOEFlag="0" />
+          <Record DINum="35" NumDO="29" NumCounter="0" NumAI="58" NumAO="0" NumDev="2" SOEFlag="0" />
+          <Record DINum="19" NumDO="19" NumCounter="0" NumAI="8" NumAO="0" NumDev="1" SOEFlag="0" />
+        </CFG_DCA>
+        <CFG_WIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Win Config">
+          <Record DPA="3" EventSize="0" ApplSize="0" PowerRestore="0" DebuggLevel="0" />
+        </CFG_WIN>
+        <DCTYPE00 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Status Input">
+          <Record Description="D4 ABSW_89b" />
+          <Record Description="D4 ABSW_89a" />
+          <Record Description="D5 ABSW_89b" />
+          <Record Description="D5 ABSW_89a" />
+          <Record Description="CSW_Bk1_89b" />
+          <Record Description="CSW_Bk1_89a" />
+          <Record Description="CSW_Bk2_89b" />
+          <Record Description="CSW_Bk2_89a" />
+          <Record Description="B2 GCB (RS)" />
+          <Record Description="SPARE 10" />
+          <Record Description="Master Reset" />
+          <Record Description="SPARE 12" />
+          <Record Description="Bank 1 GCB" />
+          <Record Description="SPARE 14" />
+          <Record Description="Bank 2 GCB" />
+          <Record Description="Bank 1 Ground Switch" />
+          <Record Description="S721 GCB" />
+          <Record Description="S721 GCB (recloser enable future)" />
+          <Record Description="R772 GCB" />
+          <Record Description="R721 GCB (recloser enable future)" />
+          <Record Description="Cap 1 GCB" />
+          <Record Description="Bank 3 GCB" />
+          <Record Description="SPARE 23" />
+          <Record Description="SPARE 24" />
+          <Record Description="Bank 4 GCB" />
+          <Record Description="Bus Tie GCB  34.5 kV" />
+          <Record Description="SPARE 27" />
+          <Record Description="Distribution Relay Failure" />
+          <Record Description="17011 VCB" />
+          <Record Description="17012 VCB" />
+          <Record Description="SPARE 31" />
+          <Record Description="SPARE 32" />
+          <Record Description="Bank 4 VCB" />
+          <Record Description="Bus Tie VCB  12.5 kV" />
+          <Record Description="SPARE 35" />
+          <Record Description="SPARE 36" />
+          <Record Description="Bank 3 ACB" />
+          <Record Description="17013 ACB" />
+          <Record Description="SPARE 39" />
+          <Record Description="SPARE 40" />
+          <Record Description="17014 ACB" />
+          <Record Description="Bank 3  5 % Voltage Reduction" />
+          <Record Description="115/34.5kV SPARE TR CRITICAL ALARM" />
+          <Record Description="115/34.5kV SPARE TR NON-CRITICAL AL" />
+          <Record Description="Bank 4  5 % Voltage Reduction" />
+          <Record Description="SPARE 46" />
+          <Record Description="Adaptive Relaying" />
+          <Record Description="Local/ Remote" />
+          <Record Description="SPARE 49" />
+          <Record Description="Transmission Relay Failure" />
+          <Record Description="Carrier Alarm" />
+          <Record Description="115KV Pequest River Comm Channel Alarm" />
+          <Record Description="Loss of Relaying Potential" />
+          <Record Description="Breaker Failure to Trip Cuttoff Switch" />
+          <Record Description="Breaker Failure to Trip Operation" />
+          <Record Description="Communication Processor Failure" />
+          <Record Description="Direct Transfer Trip Received" />
+          <Record Description="TWM FAILURE" />
+          <Record Description="TWM ALARM" />
+          <Record Description="SPARE 60" />
+          <Record Description="STATION CRITICAL" />
+          <Record Description="STATION NON-CRITICAL" />
+          <Record Description="SUBSTATION ANNUNCIATOR FAILURE" />
+          <Record Description="SPARE 64" />
+          <Record Description="SPARE 65" />
+          <Record Description="SPARE 66" />
+          <Record Description="SPARE 67" />
+          <Record Description="SPARE 68" />
+          <Record Description="SPARE 69" />
+          <Record Description="SPARE 70" />
+          <Record Description="SPARE 71" />
+          <Record Description="SPARE 72" />
+          <Record Description="SPARE 73" />
+          <Record Description="SPARE 74" />
+          <Record Description="SPARE 75" />
+          <Record Description="SPARE 76" />
+          <Record Description="SPARE 77" />
+          <Record Description="SPARE 78" />
+          <Record Description="SPARE 79" />
+          <Record Description="SPARE 80" />
+          <Record Description="SPARE 81" />
+          <Record Description="SPARE 82" />
+          <Record Description="SPARE 83" />
+          <Record Description="SPARE 84" />
+          <Record Description="SPARE 85" />
+          <Record Description="SPARE 86" />
+          <Record Description="SPARE 87" />
+          <Record Description="SPARE 88" />
+          <Record Description="SPARE 89" />
+          <Record Description="SPARE 90" />
+          <Record Description="SPARE 91" />
+          <Record Description="SPARE 92" />
+          <Record Description="SPARE 93" />
+          <Record Description="SPARE 94" />
+          <Record Description="SPARE 95" />
+          <Record Description="SPARE 96" />
+          <Record Description="SPARE 97" />
+          <Record Description="SPARE 98" />
+          <Record Description="SPARE 99" />
+          <Record Description="SPARE 100" />
+          <Record Description="SPARE 101" />
+          <Record Description="SPARE 102" />
+          <Record Description="SPARE 103" />
+          <Record Description="SPARE 104" />
+          <Record Description="SPARE 105" />
+          <Record Description="SPARE 106" />
+          <Record Description="SPARE 107" />
+          <Record Description="SPARE 108" />
+          <Record Description="SPARE 109" />
+          <Record Description="SPARE 110" />
+          <Record Description="SPARE 111" />
+          <Record Description="SPARE 112" />
+          <Record Description="SPARE 113" />
+          <Record Description="SPARE 114" />
+          <Record Description="SPARE 115" />
+          <Record Description="SPARE 116" />
+          <Record Description="SPARE 117" />
+          <Record Description="SPARE 118" />
+          <Record Description="SPARE 119" />
+          <Record Description="SPARE 120" />
+          <Record Description="SPARE 121" />
+          <Record Description="SPARE 122" />
+          <Record Description="SPARE 123" />
+          <Record Description="SPARE 124" />
+          <Record Description="SPARE 125" />
+          <Record Description="SPARE 126" />
+          <Record Description="SPARE 127" />
+          <Record Description="SPARE 128" />
+          <Record Description="System Not Redundant(On), Redundant(Off)" />
+          <Record Description="2nd CCU Comm Fail(On), OK(Off)" />
+          <Record Description="2nd CCU in Service(On), Not in Serv(Off)" />
+          <Record Description="2nd CCU Config Corrupt(On), OK(Off)" />
+          <Record Description="CCU A(On)/B(Off) Active" />
+          <Record Description="D20AD Communication Trouble" />
+          <Record Description="D20SD1 Communication Trouble" />
+          <Record Description="D20SD2 Communication Trouble" />
+          <Record Description="D20KR1 Communication Trouble" />
+          <Record Description="D20KR2 Communication Trouble" />
+          <Record Description="BANK 4 SATEC METER COMM WD" />
+          <Record Description="17011 SATEC METER COMM WD" />
+          <Record Description="17012 SATEC METER COMM WD" />
+          <Record Description="BANK 3 SATEC METER COMM WD" />
+          <Record Description="17013 SATEC METER COMM WD" />
+          <Record Description="17014 SATEC METER COMM WD" />
+          <Record Description="CAP 1 SATEC METER COMM WD" />
+          <Record Description="S919 SATEC METER PM174 COMM WD" />
+          <Record Description="SEL-3530 RTAC1 DATA CONCENTRATOR COMM WD" />
+          <Record Description="115KV BKR B2 SEL-501 COMM WD" />
+          <Record Description="115KV PEQUEST RIVER SEL-421 COMM WD" />
+          <Record Description="SPARE COMM 22" />
+          <Record Description="SPARE COMM 23" />
+          <Record Description="SPARE COMM 24" />
+          <Record Description="SPARE COMM 25" />
+          <Record Description="D20 PERIPHERAL COMM (Calc 1)" />
+          <Record Description="METER COMM (Calc 2)" />
+          <Record Description="RELAY COMM (Calc 3)" />
+          <Record Description="STATION NON-CRITICAL (Calc 4)" />
+          <Record Description="STATION CRITICAL (Calc 5)" />
+          <Record Description="SPARE (Calc 6)" />
+          <Record Description="SPARE (Calc 7)" />
+          <Record Description="SPARE (Calc 8)" />
+          <Record Description="SPARE (Calc 9)" />
+          <Record Description="SPARE (Calc 10)" />
+          <Record Description="SPARE (Calc 11)" />
+          <Record Description="SPARE (Calc 12)" />
+          <Record Description="SPARE (Calc 13)" />
+          <Record Description="SPARE (Calc 14)" />
+          <Record Description="SPARE (Calc 15)" />
+          <Record Description="SPARE (Calc 16)" />
+          <Record Description="SPARE (Calc 17)" />
+          <Record Description="SPARE (Calc 18)" />
+          <Record Description="SPARE (Calc 19)" />
+          <Record Description="SPARE (Calc 20)" />
+          <Record Description="DEVICES GLOBALLY DISABLED" />
+          <Record Description="POLLING GLOBALLY DISABLED" />
+          <Record Description="UNSOLICITED RESPONSES GLOBALLY DISABLED" />
+          <Record Description="Bank 4 DEVICES ENABLED" />
+          <Record Description="Bank 4 POLLING ENABLED" />
+          <Record Description="Bank 4 UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="Bank 4 POLL DEVICE FOR DATA" />
+          <Record Description="Bank 4 RESTART REMOTE DEVICE" />
+          <Record Description="Bank 4 TIMESYNC REMOTE DEVICE" />
+          <Record Description="Bank 4 PROPAGATION MEASUREMENT DELAY" />
+          <Record Description="Bank 4 PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="Bank 4 SECONDARY COMM CHANNEL STATUS" />
+          <Record Description="Bank 4 PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="Bank 4 SECONDARY COMM CHANNEL IN USE" />
+          <Record Description="Bank 4 IIN RESTART BIT STATE" />
+          <Record Description="Bank 4 IIN TROUBLE BIT STATE" />
+          <Record Description="Bank 4 IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="Bank 4 IIN BUFFER OVERFLOW" />
+          <Record Description="Bank 4 IIN CONFIGURATION CORRUPT" />
+          <Record Description="17011 LINE DEVICES ENABLED" />
+          <Record Description="17011 LINE POLLING ENABLED" />
+          <Record Description="17011 LINE UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="17011 LINE POLL DEVICE FOR DATA" />
+          <Record Description="17011 LINE RESTART REMOTE DEVICE" />
+          <Record Description="17011 LINE TIMESYNC REMOTE DEVICE" />
+          <Record Description="17011 LINE PROPAGATION MEASUREMENT DELA" />
+          <Record Description="17011 LINE PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="17011 LINE SECONDARY COMM CHANNEL STATU" />
+          <Record Description="17011 LINE PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="17011 LINE SECONDARY COMM CHANNEL IN US" />
+          <Record Description="17011 LINE IIN RESTART BIT STATE" />
+          <Record Description="17011 LINE IIN TROUBLE BIT STATE" />
+          <Record Description="17011 LINE IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="17011 LINE IIN BUFFER OVERFLOW" />
+          <Record Description="17011 LINE IIN CONFIGURATION CORRUPT" />
+          <Record Description="17012 LINE DEVICES ENABLED" />
+          <Record Description="17012 LINE POLLING ENABLED" />
+          <Record Description="17012 LINE UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="17012 LINE POLL DEVICE FOR DATA" />
+          <Record Description="17012 LINE RESTART REMOTE DEVICE" />
+          <Record Description="17012 LINE TIMESYNC REMOTE DEVICE" />
+          <Record Description="17012 LINE PROPAGATION MEASUREMENT DELA" />
+          <Record Description="17012 LINE PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="17012 LINE SECONDARY COMM CHANNEL STATU" />
+          <Record Description="17012 LINE PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="17012 LINE SECONDARY COMM CHANNEL IN US" />
+          <Record Description="17012 LINE IIN RESTART BIT STATE" />
+          <Record Description="17012 LINE IIN TROUBLE BIT STATE" />
+          <Record Description="17012 LINE IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="17012 LINE IIN BUFFER OVERFLOW" />
+          <Record Description="17012 LINE IIN CONFIGURATION CORRUPT" />
+          <Record Description="DEVICES GLOBALLY DISABLED" />
+          <Record Description="POLLING GLOBALLY DISABLED" />
+          <Record Description="UNSOLICITED RESPONSES GLOBALLY DISABLED" />
+          <Record Description="Bank 3 DEVICES ENABLED" />
+          <Record Description="Bank 3 POLLING ENABLED" />
+          <Record Description="Bank 3 UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="Bank 3 POLL DEVICE FOR DATA" />
+          <Record Description="Bank 3 RESTART REMOTE DEVICE" />
+          <Record Description="Bank 3 TIMESYNC REMOTE DEVICE" />
+          <Record Description="Bank 3 PROPAGATION MEASUREMENT DELAY" />
+          <Record Description="Bank 3 PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="Bank 3 SECONDARY COMM CHANNEL STATUS" />
+          <Record Description="Bank 3 PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="Bank 3 SECONDARY COMM CHANNEL IN USE" />
+          <Record Description="Bank 3 IIN RESTART BIT STATE" />
+          <Record Description="Bank 3 IIN TROUBLE BIT STATE" />
+          <Record Description="Bank 3 IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="Bank 3 IIN BUFFER OVERFLOW" />
+          <Record Description="Bank 3 IIN CONFIGURATION CORRUPT" />
+          <Record Description="17013 LINE DEVICES ENABLED" />
+          <Record Description="17013 LINE POLLING ENABLED" />
+          <Record Description="17013 LINE UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="17013 LINE POLL DEVICE FOR DATA" />
+          <Record Description="17013 LINE RESTART REMOTE DEVICE" />
+          <Record Description="17013 LINE TIMESYNC REMOTE DEVICE" />
+          <Record Description="17013 LINE PROPAGATION MEASUREMENT DELA" />
+          <Record Description="17013 LINE PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="17013 LINE SECONDARY COMM CHANNEL STATU" />
+          <Record Description="17013 LINE PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="17013 LINE SECONDARY COMM CHANNEL IN US" />
+          <Record Description="17013 LINE IIN RESTART BIT STATE" />
+          <Record Description="17013 LINE IIN TROUBLE BIT STATE" />
+          <Record Description="17013 LINE IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="17013 LINE IIN BUFFER OVERFLOW" />
+          <Record Description="17013 LINE IIN CONFIGURATION CORRUPT" />
+          <Record Description="17014 LINE DEVICES ENABLED" />
+          <Record Description="17014 LINE POLLING ENABLED" />
+          <Record Description="17014 LINE UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="17014 LINE POLL DEVICE FOR DATA" />
+          <Record Description="17014 LINE RESTART REMOTE DEVICE" />
+          <Record Description="17014 LINE TIMESYNC REMOTE DEVICE" />
+          <Record Description="17014 LINE PROPAGATION MEASUREMENT DELA" />
+          <Record Description="17014 LINE PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="17014 LINE SECONDARY COMM CHANNEL STATU" />
+          <Record Description="17014 LINE PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="17014 LINE SECONDARY COMM CHANNEL IN US" />
+          <Record Description="17014 LINE IIN RESTART BIT STATE" />
+          <Record Description="17014 LINE IIN TROUBLE BIT STATE" />
+          <Record Description="17014 LINE IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="17014 LINE IIN BUFFER OVERFLOW" />
+          <Record Description="17014 LINE IIN CONFIGURATION CORRUPT" />
+          <Record Description="DEVICES GLOBALLY DISABLED" />
+          <Record Description="POLLING GLOBALLY DISABLED" />
+          <Record Description="UNSOLICITED RESPONSES GLOBALLY DISABLED" />
+          <Record Description="Cap 1 DEVICES ENABLED" />
+          <Record Description="Cap 1 POLLING ENABLED" />
+          <Record Description="Cap 1 UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="Cap 1 POLL DEVICE FOR DATA" />
+          <Record Description="Cap 1 RESTART REMOTE DEVICE" />
+          <Record Description="Cap 1 TIMESYNC REMOTE DEVICE" />
+          <Record Description="Cap 1 PROPAGATION MEASUREMENT DELAY" />
+          <Record Description="Cap 1 PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="Cap 1 SECONDARY COMM CHANNEL STATUS" />
+          <Record Description="Cap 1 PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="Cap 1 SECONDARY COMM CHANNEL IN USE" />
+          <Record Description="Cap 1 IIN RESTART BIT STATE" />
+          <Record Description="Cap 1 IIN TROUBLE BIT STATE" />
+          <Record Description="Cap 1 IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="Cap 1 IIN BUFFER OVERFLOW" />
+          <Record Description="Cap 1 IIN CONFIGURATION CORRUPT" />
+          <Record Description="S919 DEVICES ENABLED" />
+          <Record Description="S919 POLLING ENABLED" />
+          <Record Description="S919 UNSOLICITED RESPONSE ENABLED" />
+          <Record Description="S919 POLL DEVICE FOR DATA" />
+          <Record Description="S919 RESTART REMOTE DEVICE" />
+          <Record Description="S919 TIMESYNC REMOTE DEVICE" />
+          <Record Description="S919 PROPAGATION MEASUREMENT DELAY" />
+          <Record Description="S919 PRIMARY COMM CHANNEL STATUS" />
+          <Record Description="S919 SECONDARY COMM CHANNEL STATUS" />
+          <Record Description="S919 PRIMARY COMM CHANNEL IN USE" />
+          <Record Description="S919 SECONDARY COMM CHANNEL IN USE" />
+          <Record Description="S919 IIN RESTART BIT STATE" />
+          <Record Description="S919 IIN TROUBLE BIT STATE" />
+          <Record Description="S919 IIN LOCAL BIT STATE LOCAL" />
+          <Record Description="S919 IIN BUFFER OVERFLOW" />
+          <Record Description="S919 IIN CONFIGURATION CORRUPT" />
+          <Record Description="Global DEVICES DISABLED" />
+          <Record Description="Global POLLING DISABLED ALL DEV" />
+          <Record Description="Global DISABLE UNSOL RESP ALL DEV" />
+          <Record Description="ENABLED/DISABLED DEVICE" />
+          <Record Description="POLLING ENABLED/DISABLED" />
+          <Record Description="UNSOL RESP ENABLED/DISABLED" />
+          <Record Description="POLL FOR DATA" />
+          <Record Description="REMOTE RESTART" />
+          <Record Description="TIME SYNC REMOTE" />
+          <Record Description="PROPAGATION DELAY MEASURE" />
+          <Record Description="PRI COMM CHANNEL STATUS" />
+          <Record Description="SEC COMM CHANNEL STATUS" />
+          <Record Description="PRI CHANNEL IN USE" />
+          <Record Description="SEC CHANNEL IN USE" />
+          <Record Description="IIN RESTART BIT STATE" />
+          <Record Description="IIN TROUBLE BIT STATE" />
+          <Record Description="IIN LOCAL BIT STATE" />
+          <Record Description="IIN BUFFER OVERFL BIT STATE" />
+          <Record Description="IIN CONFIG CORRUPT BIT STATE" />
+        </DCTYPE00>
+        <DCTYPE06 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Accumulator" />
+        <DCTYPE0A Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input">
+          <Record Description="S721 MW" />
+          <Record Description="S721 Mvar" />
+          <Record Description="R772 MW" />
+          <Record Description="R772 Mvar" />
+          <Record Description="Bk1 MW" />
+          <Record Description="Bk1 Mvar" />
+          <Record Description="BK2 MW" />
+          <Record Description="BK2 Mvar" />
+          <Record Description="SPARE 9" />
+          <Record Description="SPARE 10" />
+          <Record Description="SPARE 11" />
+          <Record Description="SPARE 12" />
+          <Record Description="R918 MW" />
+          <Record Description="R918 Mvar" />
+          <Record Description="R918 kV" />
+          <Record Description="34.5 Bus kV" />
+          <Record Description="Station_Battery_Voltage" />
+          <Record Description="SPARE 18" />
+          <Record Description="SPARE 19" />
+          <Record Description="SPARE 20" />
+          <Record Description="SPARE 21" />
+          <Record Description="SPARE 22" />
+          <Record Description="SPARE 23" />
+          <Record Description="SPARE 24" />
+          <Record Description="SPARE 25" />
+          <Record Description="SPARE 26" />
+          <Record Description="SPARE 27" />
+          <Record Description="SPARE 28" />
+          <Record Description="SPARE 29" />
+          <Record Description="SPARE 30" />
+          <Record Description="SPARE 31" />
+          <Record Description="SPARE 32" />
+          <Record Description="Bank 4 PH A VOLTS" />
+          <Record Description="Bank 4 PH B VOLTS" />
+          <Record Description="Bank 4 PH C VOLTS" />
+          <Record Description="Bank 4 PH A AMPS" />
+          <Record Description="Bank 4 PH B AMPS" />
+          <Record Description="Bank 4 PH C AMPS" />
+          <Record Description="Bank 4 PH A KW" />
+          <Record Description="Bank 4 PH B KW" />
+          <Record Description="Bank 4 PH C KW" />
+          <Record Description="Bank 4 PH A KX" />
+          <Record Description="Bank 4 PH B KX" />
+          <Record Description="Bank 4 PH C KX" />
+          <Record Description="Bank 4 PH A KVA" />
+          <Record Description="Bank 4 PH B KVA" />
+          <Record Description="Bank 4 PH C KVA" />
+          <Record Description="Bank 4 PH A PF" />
+          <Record Description="Bank 4 PH B PF" />
+          <Record Description="Bank 4 PH C PF" />
+          <Record Description="Bank 4 TOTAL PF" />
+          <Record Description="Bank 4 TOTAL KW" />
+          <Record Description="Bank 4 TOTAL KX" />
+          <Record Description="Bank 4 TOTAL KVA" />
+          <Record Description="Bank 4 NEURTAL AMPS" />
+          <Record Description="Bank 4 FREQ" />
+          <Record Description="Bank 4 DEVICE ONE WAY PATH DELAY" />
+          <Record Description="Bank 4 DEVICE # SUCCESSFULL TRANSACTION" />
+          <Record Description="Bank 4 DEVICE # COMM FAILURES" />
+          <Record Description="Bank 4 DEVICE PRESENT CHANNEL" />
+          <Record Description="Bank 4 DEVICE % SUCCESSFULL TRANSACTION" />
+          <Record Description="17011 LINE PH A VOLTS" />
+          <Record Description="17011 LINE PH B VOLTS" />
+          <Record Description="17011 LINE PH C VOLTS" />
+          <Record Description="17011 LINE PH A AMPS" />
+          <Record Description="17011 LINE PH B AMPS" />
+          <Record Description="17011 LINE PH C AMPS" />
+          <Record Description="17011 LINE PH A KW" />
+          <Record Description="17011 LINE PH B KW" />
+          <Record Description="17011 LINE PH C KW" />
+          <Record Description="17011 LINE PH A KX" />
+          <Record Description="17011 LINE PH B KX" />
+          <Record Description="17011 LINE PH C KX" />
+          <Record Description="17011 LINE PH A KVA" />
+          <Record Description="17011 LINE PH B KVA" />
+          <Record Description="17011 LINE PH C KVA" />
+          <Record Description="17011 LINE PH A PF" />
+          <Record Description="17011 LINE PH B PF" />
+          <Record Description="17011 LINE PH C PF" />
+          <Record Description="17011 LINE TOTAL PF" />
+          <Record Description="17011 LINE TOTAL KW" />
+          <Record Description="17011 LINE TOTAL KX" />
+          <Record Description="17011 LINE TOTAL KVA" />
+          <Record Description="17011 LINE NEURTAL AMPS" />
+          <Record Description="17011 LINE FREQ" />
+          <Record Description="17011 LINE DEVICE ONE WAY PATH DELAY" />
+          <Record Description="17011 LINE DEVICE # SUCCESSFULL TRANSAC" />
+          <Record Description="17011 LINE DEVICE # COMM FAILURES" />
+          <Record Description="17011 LINE DEVICE PRESENT CHANNEL" />
+          <Record Description="17011 LINE DEVICE % SUCCESSFULL TRANSAC" />
+          <Record Description="17012 LINE PH A VOLTS" />
+          <Record Description="17012 LINE PH B VOLTS" />
+          <Record Description="17012 LINE PH C VOLTS" />
+          <Record Description="17012 LINE PH A AMPS" />
+          <Record Description="17012 LINE PH B AMPS" />
+          <Record Description="17012 LINE PH C AMPS" />
+          <Record Description="17012 LINE PH A KW" />
+          <Record Description="17012 LINE PH B KW" />
+          <Record Description="17012 LINE PH C KW" />
+          <Record Description="17012 LINE PH A KX" />
+          <Record Description="17012 LINE PH B KX" />
+          <Record Description="17012 LINE PH C KX" />
+          <Record Description="17012 LINE PH A KVA" />
+          <Record Description="17012 LINE PH B KVA" />
+          <Record Description="17012 LINE PH C KVA" />
+          <Record Description="17012 LINE PH A PF" />
+          <Record Description="17012 LINE PH B PF" />
+          <Record Description="17012 LINE PH C PF" />
+          <Record Description="17012 LINE TOTAL PF" />
+          <Record Description="17012 LINE TOTAL KW" />
+          <Record Description="17012 LINE TOTAL KX" />
+          <Record Description="17012 LINE TOTAL KVA" />
+          <Record Description="17012 LINE NEURTAL AMPS" />
+          <Record Description="17012 LINE FREQ" />
+          <Record Description="17012 LINE DEVICE ONE WAY PATH DELAY" />
+          <Record Description="17012 LINE DEVICE # SUCCESSFULL TRANSAC" />
+          <Record Description="17012 LINE DEVICE # COMM FAILURES" />
+          <Record Description="17012 LINE DEVICE PRESENT CHANNEL" />
+          <Record Description="17012 LINE DEVICE % SUCCESSFULL TRANSAC" />
+          <Record Description="Bank 3 PH A VOLTS" />
+          <Record Description="Bank 3 PH B VOLTS" />
+          <Record Description="Bank 3 PH C VOLTS" />
+          <Record Description="Bank 3 PH A AMPS" />
+          <Record Description="Bank 3 PH B AMPS" />
+          <Record Description="Bank 3 PH C AMPS" />
+          <Record Description="Bank 3 PH A KW" />
+          <Record Description="Bank 3 PH B KW" />
+          <Record Description="Bank 3 PH C KW" />
+          <Record Description="Bank 3 PH A KX" />
+          <Record Description="Bank 3 PH B KX" />
+          <Record Description="Bank 3 PH C KX" />
+          <Record Description="Bank 3 PH A KVA" />
+          <Record Description="Bank 3 PH B KVA" />
+          <Record Description="Bank 3 PH C KVA" />
+          <Record Description="Bank 3 PH A PF" />
+          <Record Description="Bank 3 PH B PF" />
+          <Record Description="Bank 3 PH C PF" />
+          <Record Description="Bank 3 TOTAL PF" />
+          <Record Description="Bank 3 TOTAL KW" />
+          <Record Description="Bank 3 TOTAL KX" />
+          <Record Description="Bank 3 TOTAL KVA" />
+          <Record Description="Bank 3 NEURTAL AMPS" />
+          <Record Description="Bank 3 FREQ" />
+          <Record Description="Bank 3 DEVICE ONE WAY PATH DELAY" />
+          <Record Description="Bank 3 DEVICE # SUCCESSFULL TRANSACTION" />
+          <Record Description="Bank 3 DEVICE # COMM FAILURES" />
+          <Record Description="Bank 3 DEVICE PRESENT CHANNEL" />
+          <Record Description="Bank 3 DEVICE % SUCCESSFULL TRANSACTION" />
+          <Record Description="17013 LINE PH A VOLTS" />
+          <Record Description="17013 LINE PH B VOLTS" />
+          <Record Description="17013 LINE PH C VOLTS" />
+          <Record Description="17013 LINE PH A AMPS" />
+          <Record Description="17013 LINE PH B AMPS" />
+          <Record Description="17013 LINE PH C AMPS" />
+          <Record Description="17013 LINE PH A KW" />
+          <Record Description="17013 LINE PH B KW" />
+          <Record Description="17013 LINE PH C KW" />
+          <Record Description="17013 LINE PH A KX" />
+          <Record Description="17013 LINE PH B KX" />
+          <Record Description="17013 LINE PH C KX" />
+          <Record Description="17013 LINE PH A KVA" />
+          <Record Description="17013 LINE PH B KVA" />
+          <Record Description="17013 LINE PH C KVA" />
+          <Record Description="17013 LINE PH A PF" />
+          <Record Description="17013 LINE PH B PF" />
+          <Record Description="17013 LINE PH C PF" />
+          <Record Description="17013 LINE TOTAL PF" />
+          <Record Description="17013 LINE TOTAL KW" />
+          <Record Description="17013 LINE TOTAL KX" />
+          <Record Description="17013 LINE TOTAL KVA" />
+          <Record Description="17013 LINE NEURTAL AMPS" />
+          <Record Description="17013 LINE FREQ" />
+          <Record Description="17013 LINE DEVICE ONE WAY PATH DELAY" />
+          <Record Description="17013 LINE DEVICE # SUCCESSFULL TRANSAC" />
+          <Record Description="17013 LINE DEVICE # COMM FAILURES" />
+          <Record Description="17013 LINE DEVICE PRESENT CHANNEL" />
+          <Record Description="17013 LINE DEVICE % SUCCESSFULL TRANSAC" />
+          <Record Description="17014 LINE PH A VOLTS" />
+          <Record Description="17014 LINE PH B VOLTS" />
+          <Record Description="17014 LINE PH C VOLTS" />
+          <Record Description="17014 LINE PH A AMPS" />
+          <Record Description="17014 LINE PH B AMPS" />
+          <Record Description="17014 LINE PH C AMPS" />
+          <Record Description="17014 LINE PH A KW" />
+          <Record Description="17014 LINE PH B KW" />
+          <Record Description="17014 LINE PH C KW" />
+          <Record Description="17014 LINE PH A KX" />
+          <Record Description="17014 LINE PH B KX" />
+          <Record Description="17014 LINE PH C KX" />
+          <Record Description="17014 LINE PH A KVA" />
+          <Record Description="17014 LINE PH B KVA" />
+          <Record Description="17014 LINE PH C KVA" />
+          <Record Description="17014 LINE PH A PF" />
+          <Record Description="17014 LINE PH B PF" />
+          <Record Description="17014 LINE PH C PF" />
+          <Record Description="17014 LINE TOTAL PF" />
+          <Record Description="17014 LINE TOTAL KW" />
+          <Record Description="17014 LINE TOTAL KX" />
+          <Record Description="17014 LINE TOTAL KVA" />
+          <Record Description="17014 LINE NEURTAL AMPS" />
+          <Record Description="17014 LINE FREQ" />
+          <Record Description="17014 LINE DEVICE ONE WAY PATH DELAY" />
+          <Record Description="17014 LINE DEVICE # SUCCESSFULL TRANSAC" />
+          <Record Description="17014 LINE DEVICE # COMM FAILURES" />
+          <Record Description="17014 LINE DEVICE PRESENT CHANNEL" />
+          <Record Description="17014 LINE DEVICE % SUCCESSFULL TRANSAC" />
+          <Record Description="Cap 1 PH A VOLTS" />
+          <Record Description="Cap 1 PH B VOLTS" />
+          <Record Description="Cap 1 PH C VOLTS" />
+          <Record Description="Cap 1 PH A AMPS" />
+          <Record Description="Cap 1 PH B AMPS" />
+          <Record Description="Cap 1 PH C AMPS" />
+          <Record Description="Cap 1 PH A KW" />
+          <Record Description="Cap 1 PH B KW" />
+          <Record Description="Cap 1 PH C KW" />
+          <Record Description="Cap 1 PH A KX" />
+          <Record Description="Cap 1 PH B KX" />
+          <Record Description="Cap 1 PH C KX" />
+          <Record Description="Cap 1 PH A KVA" />
+          <Record Description="Cap 1 PH B KVA" />
+          <Record Description="Cap 1 PH C KVA" />
+          <Record Description="Cap 1 PH A PF" />
+          <Record Description="Cap 1 PH B PF" />
+          <Record Description="Cap 1 PH C PF" />
+          <Record Description="Cap 1 TOTAL PF" />
+          <Record Description="Cap 1 TOTAL KW" />
+          <Record Description="Cap 1 TOTAL KX" />
+          <Record Description="Cap 1 TOTAL KVA" />
+          <Record Description="Cap 1 NEURTAL AMPS" />
+          <Record Description="Cap 1 FREQ" />
+          <Record Description="Cap 1 DEVICE ONE WAY PATH DELAY" />
+          <Record Description="Cap 1 DEVICE # SUCCESSFULL TRANSACTION" />
+          <Record Description="Cap 1 DEVICE # COMM FAILURES" />
+          <Record Description="Cap 1 DEVICE PRESENT CHANNEL" />
+          <Record Description="Cap 1 DEVICE % SUCCESSFULL TRANSACTION" />
+          <Record Description="115KV S919 PH A VOLTS" />
+          <Record Description="115KV S919 PH B VOLTS" />
+          <Record Description="115KV S919 PH C VOLTS" />
+          <Record Description="115KV S919 PH A AMPS" />
+          <Record Description="115KV S919 PH B AMPS" />
+          <Record Description="115KV S919 PH C AMPS" />
+          <Record Description="S919 PH A KW" />
+          <Record Description="S919 PH B KW" />
+          <Record Description="S919 PH C KW" />
+          <Record Description="S919 PH A KX" />
+          <Record Description="S919 PH B KX" />
+          <Record Description="S919 PH C KX" />
+          <Record Description="S919 PH A KVA" />
+          <Record Description="S919 PH B KVA" />
+          <Record Description="S919 PH C KVA" />
+          <Record Description="S919 PH A PF" />
+          <Record Description="S919 PH B PF" />
+          <Record Description="S919 PH C PF" />
+          <Record Description="S919 TOTAL PF" />
+          <Record Description="115 KV S919 TOTAL KW" />
+          <Record Description="115 KV S919 TOTAL KX" />
+          <Record Description="S919 TOTAL KVA" />
+          <Record Description="S919 NEURTAL AMPS" />
+          <Record Description="S919 FREQ" />
+          <Record Description="S919 DEVICE ONE WAY PATH DELAY" />
+          <Record Description="S919 DEVICE # SUCCESSFULL TRANSACTION" />
+          <Record Description="S919 DEVICE # COMM FAILURES" />
+          <Record Description="S919 DEVICE PRESENT CHANNEL" />
+          <Record Description="S919 DEVICE % SUCCESSFULL TRANSACTION" />
+          <Record Description="SEL-421 PR S919 FAULT DISTANCE" />
+          <Record Description="SEL-421 PR S919 PHASE B AMPS" />
+          <Record Description="SEL-501 115KV B2 PHASE B AMPS" />
+          <Record Description="ONE WAY TRANSMISSION DELAY" />
+          <Record Description="# OF SUCCESSFUL TRANS W/DEV" />
+          <Record Description="# OF FAILURES" />
+          <Record Description="PRESENT CHANNEL" />
+          <Record Description="% OF SUCCESSFUL TRANSACTIONS" />
+        </DCTYPE0A>
+        <DCTYPE80 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Control Output">
+          <Record Description="D4 ABSW" />
+          <Record Description="D5 ABSW" />
+          <Record Description="Bank 1 CSW" />
+          <Record Description="Bank 2 CSW" />
+          <Record Description="B2 GCB (RS)" />
+          <Record Description="Master Reset" />
+          <Record Description="Bank 1 GCB" />
+          <Record Description="Bank 2 GCB" />
+          <Record Description="S721 GCB" />
+          <Record Description="R772 GCB" />
+          <Record Description="Cap 1 GCB" />
+          <Record Description="Bank 3 GCB" />
+          <Record Description="Bank 4 GCB" />
+          <Record Description="Bus Tie GCB 34.5 kV" />
+          <Record Description="17011 VCB" />
+          <Record Description="17012 VCB" />
+          <Record Description="Bank 4 VCB" />
+          <Record Description="Bus Tie VCB 12.5 kV" />
+          <Record Description="Bank 3 ACB" />
+          <Record Description="17013 ACB" />
+          <Record Description="17014 ACB" />
+          <Record Description="Bank 3 5% Volt Red" />
+          <Record Description="Bank 4 5% Volt Red" />
+          <Record Description="Adaptive Relaying" />
+          <Record Description="SPARE 25" />
+          <Record Description="SPARE 26" />
+          <Record Description="SPARE 27" />
+          <Record Description="SPARE 28" />
+          <Record Description="SPARE 29" />
+          <Record Description="SPARE 30" />
+          <Record Description="SPARE 31" />
+          <Record Description="SPARE 32" />
+          <Record Description="SPARE 33" />
+          <Record Description="SPARE 34" />
+          <Record Description="SPARE 35" />
+          <Record Description="SPARE 36" />
+          <Record Description="SPARE 37" />
+          <Record Description="SPARE 38" />
+          <Record Description="SPARE 39" />
+          <Record Description="SPARE 40" />
+          <Record Description="SPARE 41" />
+          <Record Description="SPARE 42" />
+          <Record Description="SPARE 43" />
+          <Record Description="SPARE 44" />
+          <Record Description="SPARE 45" />
+          <Record Description="SPARE 46" />
+          <Record Description="SPARE 47" />
+          <Record Description="SPARE 48" />
+          <Record Description="SPARE 49" />
+          <Record Description="SPARE 50" />
+          <Record Description="SPARE 51" />
+          <Record Description="SPARE 52" />
+          <Record Description="SPARE 53" />
+          <Record Description="SPARE 54" />
+          <Record Description="SPARE 55" />
+          <Record Description="SPARE 56" />
+          <Record Description="SPARE 57" />
+          <Record Description="SPARE 58" />
+          <Record Description="SPARE 59" />
+          <Record Description="SPARE 60" />
+          <Record Description="SPARE 61" />
+          <Record Description="SPARE 62" />
+          <Record Description="SPARE 63" />
+          <Record Description="SPARE 64" />
+          <Record Description="GLOBAL DCA DISABLE" />
+          <Record Description="GLOBAL DISABLE POLLING" />
+          <Record Description="GLOBAL DISABLE UNSOLICITED RESPONSE" />
+          <Record Description="GLOBAL CLASS DATA POLL" />
+          <Record Description="GLOBAL INTEGRITY DATA POLL" />
+          <Record Description="GLOBAL STOP/START DEVICES" />
+          <Record Description="GLOBAL TIMESYNC DEVICES" />
+          <Record Description="GLOBAL CLEAR ALL DEVICES" />
+          <Record Description="GLOBAL CLEAR COMM STATS" />
+          <Record Description="Bank 4 ENABLE DEVICE DCA" />
+          <Record Description="Bank 4 ENABLE DEVICE POLLING" />
+          <Record Description="Bank 4 ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="Bank 4 DEVICE CLASS DATA POLL" />
+          <Record Description="Bank 4 DEVICE INTEGRITY DATA POLL" />
+          <Record Description="Bank 4 DEVICE START/STOP APPLICATION" />
+          <Record Description="Bank 4 DEVICE TIMESYNC" />
+          <Record Description="Bank 4 DEVICE PROP. DELAY MEASUREMENT" />
+          <Record Description="Bank 4 DEVICE FORCE TO NEXT COMM CHAN" />
+          <Record Description="Bank 4 CLEAR DEVICE COMM STATS" />
+          <Record Description="17011 LINE ENABLE DEVICE DCA" />
+          <Record Description="17011 LINE ENABLE DEVICE POLLING" />
+          <Record Description="17011 LINE ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="17011 LINE DEVICE CLASS DATA POLL" />
+          <Record Description="17011 LINE DEVICE INTEGRITY DATA POLL" />
+          <Record Description="17011 LINE DEVICE START/STOP APPLICATIO" />
+          <Record Description="17011 LINE DEVICE TIMESYNC" />
+          <Record Description="17011 LINE DEVICE PROP. DELAY MEASUREME" />
+          <Record Description="17011 LINE DEVICE FORCE TO NEXT COMM CH" />
+          <Record Description="17011 LINE CLEAR DEVICE COMM STATS" />
+          <Record Description="17012 LINE ENABLE DEVICE DCA" />
+          <Record Description="17012 LINE ENABLE DEVICE POLLING" />
+          <Record Description="17012 LINE ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="17012 LINE DEVICE CLASS DATA POLL" />
+          <Record Description="17012 LINE DEVICE INTEGRITY DATA POLL" />
+          <Record Description="17012 LINE DEVICE START/STOP APPLICATIO" />
+          <Record Description="17012 LINE DEVICE TIMESYNC" />
+          <Record Description="17012 LINE DEVICE PROP. DELAY MEASUREME" />
+          <Record Description="17012 LINE DEVICE FORCE TO NEXT COMM CH" />
+          <Record Description="17012 LINE CLEAR DEVICE COMM STATS" />
+          <Record Description="GLOBAL DCA DISABLE" />
+          <Record Description="GLOBAL DISABLE POLLING" />
+          <Record Description="GLOBAL DISABLE UNSOLICITED RESPONSE" />
+          <Record Description="GLOBAL CLASS DATA POLL" />
+          <Record Description="GLOBAL INTEGRITY DATA POLL" />
+          <Record Description="GLOBAL STOP/START DEVICES" />
+          <Record Description="GLOBAL TIMESYNC DEVICES" />
+          <Record Description="GLOBAL CLEAR ALL DEVICES" />
+          <Record Description="GLOBAL CLEAR COMM STATS" />
+          <Record Description="Bank 3 ENABLE DEVICE DCA" />
+          <Record Description="Bank 3 ENABLE DEVICE POLLING" />
+          <Record Description="Bank 3 ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="Bank 3 DEVICE CLASS DATA POLL" />
+          <Record Description="Bank 3 DEVICE INTEGRITY DATA POLL" />
+          <Record Description="Bank 3 DEVICE START/STOP APPLICATION" />
+          <Record Description="Bank 3 DEVICE TIMESYNC" />
+          <Record Description="Bank 3 DEVICE PROP. DELAY MEASUREMENT" />
+          <Record Description="Bank 3 DEVICE FORCE TO NEXT COMM CHAN" />
+          <Record Description="Bank 3 CLEAR DEVICE COMM STATS" />
+          <Record Description="17013 LINE ENABLE DEVICE DCA" />
+          <Record Description="17013 LINE ENABLE DEVICE POLLING" />
+          <Record Description="17013 LINE ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="17013 LINE DEVICE CLASS DATA POLL" />
+          <Record Description="17013 LINE DEVICE INTEGRITY DATA POLL" />
+          <Record Description="17013 LINE DEVICE START/STOP APPLICATIO" />
+          <Record Description="17013 LINE DEVICE TIMESYNC" />
+          <Record Description="17013 LINE DEVICE PROP. DELAY MEASUREME" />
+          <Record Description="17013 LINE DEVICE FORCE TO NEXT COMM CH" />
+          <Record Description="17013 LINE CLEAR DEVICE COMM STATS" />
+          <Record Description="17014 LINE ENABLE DEVICE DCA" />
+          <Record Description="17014 LINE ENABLE DEVICE POLLING" />
+          <Record Description="17014 LINE ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="17014 LINE DEVICE CLASS DATA POLL" />
+          <Record Description="17014 LINE DEVICE INTEGRITY DATA POLL" />
+          <Record Description="17014 LINE DEVICE START/STOP APPLICATIO" />
+          <Record Description="17014 LINE DEVICE TIMESYNC" />
+          <Record Description="17014 LINE DEVICE PROP. DELAY MEASUREME" />
+          <Record Description="17014 LINE DEVICE FORCE TO NEXT COMM CH" />
+          <Record Description="17014 LINE CLEAR DEVICE COMM STATS" />
+          <Record Description="GLOBAL DCA DISABLE" />
+          <Record Description="GLOBAL DISABLE POLLING" />
+          <Record Description="GLOBAL DISABLE UNSOLICITED RESPONSE" />
+          <Record Description="GLOBAL CLASS DATA POLL" />
+          <Record Description="GLOBAL INTEGRITY DATA POLL" />
+          <Record Description="GLOBAL STOP/START DEVICES" />
+          <Record Description="GLOBAL TIMESYNC DEVICES" />
+          <Record Description="GLOBAL CLEAR ALL DEVICES" />
+          <Record Description="GLOBAL CLEAR COMM STATS" />
+          <Record Description="Cap 1 ENABLE DEVICE DCA" />
+          <Record Description="Cap 1 ENABLE DEVICE POLLING" />
+          <Record Description="Cap 1 ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="Cap 1 DEVICE CLASS DATA POLL" />
+          <Record Description="Cap 1 DEVICE INTEGRITY DATA POLL" />
+          <Record Description="Cap 1 DEVICE START/STOP APPLICATION" />
+          <Record Description="Cap 1 DEVICE TIMESYNC" />
+          <Record Description="Cap 1 DEVICE PROP. DELAY MEASUREMENT" />
+          <Record Description="Cap 1 DEVICE FORCE TO NEXT COMM CHAN" />
+          <Record Description="Cap 1 CLEAR DEVICE COMM STATS" />
+          <Record Description="S919 ENABLE DEVICE DCA" />
+          <Record Description="S919 ENABLE DEVICE POLLING" />
+          <Record Description="S919 ENABLE DEVICE UNSOL. POLLING" />
+          <Record Description="S919 DEVICE CLASS DATA POLL" />
+          <Record Description="S919 DEVICE INTEGRITY DATA POLL" />
+          <Record Description="S919 DEVICE START/STOP APPLICATION" />
+          <Record Description="S919 DEVICE TIMESYNC" />
+          <Record Description="S919 DEVICE PROP. DELAY MEASUREMENT" />
+          <Record Description="S919 DEVICE FORCE TO NEXT COMM CHAN" />
+          <Record Description="S919 CLEAR DEVICE COMM STATS" />
+          <Record Description="Global DISABLE ALLGlobal DISABLE ALL DEV" />
+          <Record Description="Global DISABLE POLLS TO ALL DEV" />
+          <Record Description="Global DISABLE UNSOL RESP" />
+          <Record Description="Global POLL ALL DEV FOR CLSS DATA" />
+          <Record Description="Global POLL ALL DEV FOR INTG DATA" />
+          <Record Description="Global RESTART ALL DEV" />
+          <Record Description="Global TIMESYNC ALL DEV" />
+          <Record Description="Global CLEAR CHANNEL" />
+          <Record Description="Global CLEAR COMM STATISTIC" />
+          <Record Description="DEVICE ENABLED" />
+          <Record Description="SCHEDULED POLLS ENABLED" />
+          <Record Description="UNSOLICITED RESP ENABLED" />
+          <Record Description="POLL DEV FOR CLASS DATA" />
+          <Record Description="POLL DEV FOR INTEG DATA" />
+          <Record Description="DEVICE RESTART" />
+          <Record Description="TIMESYNC IN PROGRESS" />
+          <Record Description="PROPAGATION DELAY IN PROG" />
+          <Record Description="FORCE NEXT COM CHANNEL" />
+          <Record Description="CLEAR COMM STATISTIC" />
+        </DCTYPE80>
+        <DCTYPEA0 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output" />
+        <DCTYPECO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Complex Object" />
+        <DCTYPEDS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Status">
+          <Record Description="D20 A Analog Input Peripheral (32 AI)" />
+          <Record Description="D20 SD1 Digital Input Peripheral (64 DI)" />
+          <Record Description="D20 SD2 Digital Input Peripheral (64 DI)" />
+          <Record Description="D20 KR1 Control Output Peripheral (32DO)" />
+          <Record Description="D20 KR2 Control Output Peripheral (32DO)" />
+          <Record Description="Bank 4 Satec Meter (Addr 50)" />
+          <Record Description="17011 Satec Meter (Addr 51)" />
+          <Record Description="17012 Satec Meter (Addr 52)" />
+          <Record Description="Bank 3 Satec Meter (Addr 60)" />
+          <Record Description="17013 Satec Meter (Addr 61)" />
+          <Record Description="17014 Satec Meter (Addr 62)" />
+          <Record Description="Cap 1 Satec Meter (Addr 70)" />
+          <Record Description="S919 PM174 Satec Meter (Addr 71)" />
+          <Record Description="RTAC1 DATA CONCENTRATOR (Addr 21)" />
+        </DCTYPEDS>
+        <DCTYPEGD Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Advanced Data" />
+      </Application>
+      <Application xsi:type="B009_400:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B009_400="http://www.ge.com/CCE/B009_400" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B009_400 B009_400_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Mailbox DTA" Application_Type="DTA" Application_Description="Mailbox system point conversion application." Application_Identifier="B009" Application_Version="400" Application_Revision="0" DCA_Index="18" Enabled="False">
+        <B009_2_1 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="D/O To D/I Map" />
+        <B009_5_1 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="A/O To D/I Map" />
+        <B009_5_3 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="A/O To Counter Map" />
+        <B009_5_4 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="A/O To A/I Map" />
+        <B009_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Master To Master" />
+        <B009_DCA Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Parameters">
+          <Record />
+        </B009_DCA>
+      </Application>
+      <Application xsi:type="B012_112:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B012_112="http://www.ge.com/CCE/B012_112" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B012_112 B012_112_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="IRIG-B" Application_Type="DCA" Application_Description="IRIG-B universal time coordination." Application_Identifier="B012" Application_Version="112" Application_Revision="0" DCA_Index="19" Enabled="False">
+        <B012_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Configuration">
+          <Record DCA_x0020_Index="19" />
+        </B012_CFG>
+      </Application>
+      <Application xsi:type="B013_541:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B013_541="http://www.ge.com/CCE/B013_541" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B013_541 B013_541_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="DNP V3.00 Data Link" Application_Type="DATA_LINK" Application_Description="Distributed network protocol (DNP) V3.00 data link configuration." Application_Identifier="B013" Application_Version="541" Application_Revision="0" DCA_Index="-1" Enabled="True">
+        <B013_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record Port="COM1" Baud_x0020_Rate="38.4k" Reset_x0020_Link_x0020_on_x0020_Rx_x0020_NACK="Disabled" DCD="Disabled" RTS="Disabled" CTS="Disabled" DCD_x0020_to_x0020_Rx_x0020_Enable_x0020_Time="10" RTS_x0020_Preamble="25" RTS_x0020_Postamble="18" Max_x0020_Frame_x0020_Size="249" Transmit_x0020_Retries="3" Transmit_x0020_Buffers="10" Receive_x0020_Buffers="10" Confirm_x0020_Timeout="1000" Response_x0020_Timeout="1000" Extra_x0020_Character_x0020_Timeout="0" Statistics_x0020_Location="NVRAM" Statistics_x0020_Restart="Zero all statistics" Minimum_x0020_Frame_x0020_Delay="0">
+            <Dial-Up_x0020_Modem>
+              <Record Dial-Up_x0020_Modem="Disabled" Initialization_x0020_String="ATE0V0S0=2S7=25" Number_x0020_of_x0020_Devices="0" First_x0020_Device="1" Connection_x0020_Timeout="30" Redial_x0020_Retries="2" Max_x0020_Redial_x0020_Delay="0" Reconnect_x0020_Retries="0" Idle_x0020_Timeout="10" />
+            </Dial-Up_x0020_Modem>
+            <Collision_x0020_Avoidance>
+              <Record Collision_x0020_Avoidance="Disabled" Min_x0020_Link_x0020_Idle_x0020_Time="0" Max_x0020_Random_x0020_Delay="0" />
+            </Collision_x0020_Avoidance>
+          </Record>
+          <Record Port="COM5" Baud_x0020_Rate="9600" Reset_x0020_Link_x0020_on_x0020_Rx_x0020_NACK="Enabled" DCD="Disabled" RTS="Enabled" CTS="Disabled" DCD_x0020_to_x0020_Rx_x0020_Enable_x0020_Time="10" RTS_x0020_Preamble="25" RTS_x0020_Postamble="18" Max_x0020_Frame_x0020_Size="249" Transmit_x0020_Retries="3" Transmit_x0020_Buffers="10" Receive_x0020_Buffers="10" Confirm_x0020_Timeout="1000" Response_x0020_Timeout="1000" Extra_x0020_Character_x0020_Timeout="0" Statistics_x0020_Location="NVRAM" Statistics_x0020_Restart="Zero all statistics" Minimum_x0020_Frame_x0020_Delay="0">
+            <Dial-Up_x0020_Modem>
+              <Record Dial-Up_x0020_Modem="Disabled" Initialization_x0020_String="ATE0V0S0=2S7=25" Number_x0020_of_x0020_Devices="0" First_x0020_Device="1" Connection_x0020_Timeout="30" Redial_x0020_Retries="2" Max_x0020_Redial_x0020_Delay="0" Reconnect_x0020_Retries="0" Idle_x0020_Timeout="10" />
+            </Dial-Up_x0020_Modem>
+            <Collision_x0020_Avoidance>
+              <Record Collision_x0020_Avoidance="Disabled" Min_x0020_Link_x0020_Idle_x0020_Time="0" Max_x0020_Random_x0020_Delay="0" />
+            </Collision_x0020_Avoidance>
+          </Record>
+          <Record Port="COM6" Baud_x0020_Rate="9600" Reset_x0020_Link_x0020_on_x0020_Rx_x0020_NACK="Enabled" DCD="Disabled" RTS="Enabled" CTS="Disabled" DCD_x0020_to_x0020_Rx_x0020_Enable_x0020_Time="10" RTS_x0020_Preamble="25" RTS_x0020_Postamble="18" Max_x0020_Frame_x0020_Size="249" Transmit_x0020_Retries="3" Transmit_x0020_Buffers="10" Receive_x0020_Buffers="10" Confirm_x0020_Timeout="1000" Response_x0020_Timeout="1000" Extra_x0020_Character_x0020_Timeout="0" Statistics_x0020_Location="NVRAM" Statistics_x0020_Restart="Zero all statistics" Minimum_x0020_Frame_x0020_Delay="0">
+            <Dial-Up_x0020_Modem>
+              <Record Dial-Up_x0020_Modem="Disabled" Initialization_x0020_String="ATE0V0S0=2S7=25" Number_x0020_of_x0020_Devices="0" First_x0020_Device="1" Connection_x0020_Timeout="30" Redial_x0020_Retries="2" Max_x0020_Redial_x0020_Delay="0" Reconnect_x0020_Retries="0" Idle_x0020_Timeout="10" />
+            </Dial-Up_x0020_Modem>
+            <Collision_x0020_Avoidance>
+              <Record Collision_x0020_Avoidance="Disabled" Min_x0020_Link_x0020_Idle_x0020_Time="0" Max_x0020_Random_x0020_Delay="0" />
+            </Collision_x0020_Avoidance>
+          </Record>
+          <Record Port="COM7" Baud_x0020_Rate="9600" Reset_x0020_Link_x0020_on_x0020_Rx_x0020_NACK="Enabled" DCD="Disabled" RTS="Enabled" CTS="Disabled" DCD_x0020_to_x0020_Rx_x0020_Enable_x0020_Time="10" RTS_x0020_Preamble="25" RTS_x0020_Postamble="18" Max_x0020_Frame_x0020_Size="249" Transmit_x0020_Retries="3" Transmit_x0020_Buffers="10" Receive_x0020_Buffers="10" Confirm_x0020_Timeout="1000" Response_x0020_Timeout="1000" Extra_x0020_Character_x0020_Timeout="0" Statistics_x0020_Location="NVRAM" Statistics_x0020_Restart="Zero all statistics" Minimum_x0020_Frame_x0020_Delay="0">
+            <Dial-Up_x0020_Modem>
+              <Record Dial-Up_x0020_Modem="Disabled" Initialization_x0020_String="ATE0V0S0=2S7=25" Number_x0020_of_x0020_Devices="0" First_x0020_Device="1" Connection_x0020_Timeout="30" Redial_x0020_Retries="2" Max_x0020_Redial_x0020_Delay="0" Reconnect_x0020_Retries="0" Idle_x0020_Timeout="10" />
+            </Dial-Up_x0020_Modem>
+            <Collision_x0020_Avoidance>
+              <Record Collision_x0020_Avoidance="Disabled" Min_x0020_Link_x0020_Idle_x0020_Time="0" Max_x0020_Random_x0020_Delay="0" />
+            </Collision_x0020_Avoidance>
+          </Record>
+          <Record Port="COM2" Baud_x0020_Rate="9600" Reset_x0020_Link_x0020_on_x0020_Rx_x0020_NACK="Disabled" DCD="Disabled" RTS="Disabled" CTS="Disabled" DCD_x0020_to_x0020_Rx_x0020_Enable_x0020_Time="10" RTS_x0020_Preamble="25" RTS_x0020_Postamble="18" Max_x0020_Frame_x0020_Size="249" Transmit_x0020_Retries="3" Transmit_x0020_Buffers="10" Receive_x0020_Buffers="10" Confirm_x0020_Timeout="1000" Response_x0020_Timeout="1000" Extra_x0020_Character_x0020_Timeout="0" Statistics_x0020_Location="NVRAM" Statistics_x0020_Restart="Zero all statistics" Minimum_x0020_Frame_x0020_Delay="0">
+            <Dial-Up_x0020_Modem>
+              <Record Dial-Up_x0020_Modem="Disabled" Initialization_x0020_String="ATE0V0S0=2S7=25" Number_x0020_of_x0020_Devices="0" First_x0020_Device="1" Connection_x0020_Timeout="30" Redial_x0020_Retries="2" Max_x0020_Redial_x0020_Delay="0" Reconnect_x0020_Retries="0" Idle_x0020_Timeout="10" />
+            </Dial-Up_x0020_Modem>
+            <Collision_x0020_Avoidance>
+              <Record Collision_x0020_Avoidance="Disabled" Min_x0020_Link_x0020_Idle_x0020_Time="0" Max_x0020_Random_x0020_Delay="0" />
+            </Collision_x0020_Avoidance>
+          </Record>
+        </B013_CFG>
+        <B013_DEV Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Configuration">
+          <Record Device_x0020_Address="0" Device_x0020_Dial_x0020_String="" />
+        </B013_DEV>
+      </Application>
+      <Application xsi:type="B014-1_412:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B014-1_412="http://www.ge.com/CCE/B014-1_412" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B014-1_412 B014-1_412_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Wesmaint II+" Application_Type="WIN" Application_Description="RTU maintenance facility." Application_Identifier="B014-1" Application_Version="412" Application_Revision="0" DCA_Index="-1" Enabled="True">
+        <B014_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record Comm_x0020_Port="COM0" Port_x0020_Used_x003F_="Yes" Baud_x0020_Rate="9600" Modem_x0020_Attached_x003F_="No" Dialout_x0020_Prefix="" DCD_x0020_Wait="0" RTS_x0020_Wait="0" RTS_x0020_Clear="0" Login_x0020_Timeout="60" System_x0020_Lockout="120" Login_x0020_Attempts="4" Base_x0020_Priority="0" SOE_x0020_Buff_x0020_Size="0" COS_x0020_Buff_x0020_Size="0" Display_x0020_Type="Single Col w/Desc" Task_x0020_Name="WES0" />
+        </B014_CFG>
+        <B014_OPT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="WESMAINT Options" />
+        <B014DIAL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Modem Command Strings" />
+        <B014MCFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Buffer Configuration">
+          <Record SOE_x0020_Buffer_x0020_Size="500" COS_x0020_Buffer_x0020_Size="80" Logger_x0020_Buffer_x0020_Size="40" Login_x0020_Buffer_x0020_Size="20">
+            <Buffer_x0020_Flags>
+              <Record SOE_x0020_Location="NVRAM" COS_x0020_Location="RAM" Logger_x0020_Position="RAM" SOE_x0020_Overflow="Keep Newest Events" COS_x0020_Overflow="Keep Newest Events" Logger_x0020_Overflow="Keep Newest Events" />
+            </Buffer_x0020_Flags>
+          </Record>
+        </B014MCFG>
+        <B014USER Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="User Configuration">
+          <Record Logout_x0020_Time="1800" Callback_x0020_Delay="0" Callback_x0020_Number="" User_x0020_Name="Scada" Password="Sel-3530" Control_x0020_Password="control" Welcome_x0020_Message="Welcome To Wesmaint II+">
+            <Time_x0020_Date_x0020_Format>
+              <Record Time_x0020_Format="24 hr" Date_x0020_Separator="Hyphen" Date_x0020_Format="YY MM DD" />
+            </Time_x0020_Date_x0020_Format>
+            <Application_x0020_Control>
+              <Record Application_x0020_Number="14">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+            </Application_x0020_Control>
+          </Record>
+          <Record Logout_x0020_Time="1800" Callback_x0020_Delay="0" Callback_x0020_Number="" User_x0020_Name="supervisor" Password="rtu" Control_x0020_Password="control" Welcome_x0020_Message="Welcome To Wesmaint II+">
+            <Time_x0020_Date_x0020_Format>
+              <Record Time_x0020_Format="24 hr" Date_x0020_Separator="Hyphen" Date_x0020_Format="YY MM DD" />
+            </Time_x0020_Date_x0020_Format>
+            <Application_x0020_Control>
+              <Record Application_x0020_Number="14">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Disable" Modify-1="Disable" Modify-2="Disable" Modify-3="Disable" Modify-4="Disable" Modify-5="Disable" Modify-6="Disable" Modify-7="Disable" Modify-8="Disable" Modify-9="Disable" Modify-10="Disable" Modify-11="Disable" Modify-12="Disable" Modify-13="Disable" Modify-14="Disable" Modify-15="Disable" Modify-16="Disable" Modify-17="Disable" Modify-18="Disable" Modify-19="Disable" Modify-20="Disable" Modify-21="Disable" Modify-22="Disable" Modify-23="Disable" Modify-24="Disable" Modify-25="Disable" Modify-26="Disable" Modify-27="Disable" Modify-28="Disable" Modify-29="Disable" Modify-30="Disable" Modify-31="Disable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Disable" Display-1="Disable" Display-2="Disable" Display-3="Disable" Display-4="Disable" Display-5="Disable" Display-6="Disable" Display-7="Disable" Display-8="Disable" Display-9="Disable" Display-10="Disable" Display-11="Disable" Display-12="Disable" Display-13="Disable" Display-14="Disable" Display-15="Disable" Display-16="Disable" Display-17="Disable" Display-18="Disable" Display-19="Disable" Display-20="Disable" Display-21="Disable" Display-22="Disable" Display-23="Disable" Display-24="Disable" Display-25="Disable" Display-26="Disable" Display-27="Disable" Display-28="Disable" Display-29="Disable" Display-30="Disable" Display-31="Disable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+              <Record Application_x0020_Number="0">
+                <Modify_x0020_Access>
+                  <Record Modify-0="Enable" Modify-1="Enable" Modify-2="Enable" Modify-3="Enable" Modify-4="Enable" Modify-5="Enable" Modify-6="Enable" Modify-7="Enable" Modify-8="Enable" Modify-9="Enable" Modify-10="Enable" Modify-11="Enable" Modify-12="Enable" Modify-13="Enable" Modify-14="Enable" Modify-15="Enable" Modify-16="Enable" Modify-17="Enable" Modify-18="Enable" Modify-19="Enable" Modify-20="Enable" Modify-21="Enable" Modify-22="Enable" Modify-23="Enable" Modify-24="Enable" Modify-25="Enable" Modify-26="Enable" Modify-27="Enable" Modify-28="Enable" Modify-29="Enable" Modify-30="Enable" Modify-31="Enable" />
+                </Modify_x0020_Access>
+                <Read_x0020_Access>
+                  <Record Display-0="Enable" Display-1="Enable" Display-2="Enable" Display-3="Enable" Display-4="Enable" Display-5="Enable" Display-6="Enable" Display-7="Enable" Display-8="Enable" Display-9="Enable" Display-10="Enable" Display-11="Enable" Display-12="Enable" Display-13="Enable" Display-14="Enable" Display-15="Enable" Display-16="Enable" Display-17="Enable" Display-18="Enable" Display-19="Enable" Display-20="Enable" Display-21="Enable" Display-22="Enable" Display-23="Enable" Display-24="Enable" Display-25="Enable" Display-26="Enable" Display-27="Enable" Display-28="Enable" Display-29="Enable" Display-30="Enable" Display-31="Enable" />
+                </Read_x0020_Access>
+              </Record>
+            </Application_x0020_Control>
+          </Record>
+        </B014USER>
+        <B014WTXT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Localized Text Strings">
+          <Record />
+        </B014WTXT>
+        <LANGINFO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Localization Settings">
+          <Record EN_ENABLED="1" language="en" country="US" decimal_separator="." />
+        </LANGINFO>
+        <WWELCOME Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Welcome Message">
+          <Record Row="2" Col="1" Text_x0020_Attribute="Normal" Message="FIRST ENERGY" />
+          <Record Row="3" Col="1" Text_x0020_Attribute="Inverse" Message="FLANDERS SUBSTATION" />
+          <Record Row="5" Col="1" Text_x0020_Attribute="Normal" Message="PORT 0: ASCI MAINTENANCE (LOCAL)" />
+          <Record Row="6" Col="1" Text_x0020_Attribute="Normal" Message="PORT 1: DNP DPA TO EMS, MPLS, 38400 BAUD" />
+          <Record Row="7" Col="1" Text_x0020_Attribute="Normal" Message="PORT 2: DNP DCA SEL3530 RTAC1, 9600 BAUD" />
+          <Record Row="8" Col="1" Text_x0020_Attribute="Normal" Message="PORT 3: SPARE" />
+          <Record Row="9" Col="1" Text_x0020_Attribute="Normal" Message="PORT 4: SPARE" />
+          <Record Row="10" Col="1" Text_x0020_Attribute="Normal" Message="PORT 5: DNP DCA SATEC METERS, 9600 BAUD" />
+          <Record Row="11" Col="1" Text_x0020_Attribute="Normal" Message="PORT 6: DNP DCA SATEC METERS, 9600 BAUD" />
+          <Record Row="12" Col="1" Text_x0020_Attribute="Normal" Message="PORT 7: DNP DCA SATEC METERS, 9600 BAUD" />
+          <Record Row="14" Col="1" Text_x0020_Attribute="Normal" Message="FIRMWARE - SAB3075/10" />
+          <Record Row="15" Col="1" Text_x0020_Attribute="Inverse" Message="NEW LOGIN:" />
+        </WWELCOME>
+      </Application>
+      <Application xsi:type="B015_520:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B015_520="http://www.ge.com/CCE/B015_520" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B015_520 B015_520_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Bridgeman" Application_Type="DATA_LINK" Application_Description="Bridgeman configuration." Application_Identifier="B015" Application_Version="520" Application_Revision="0" DCA_Index="-1" Enabled="True">
+        <B015_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Configuration Table">
+          <Record Receive_x0020_Buffer_x0020_Size="2048" Number_x0020_Of_x0020_Rx_x0020_Buffers="13" Max_x0020_Devices_x0020_Added_x0020_to_x0020_Cfg="1" />
+        </B015_CFG>
+        <B015_DBT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Data Link Bridging Table" />
+        <B015_DIR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="OSI Directory Table">
+          <Record OSI_x0020_NSAP="4900000000000000" OSI_x0020_TSEL="0001" OSI_x0020_SSEL="0001" OSI_x0020_PSEL="00000001" AP-title-1="1" AP-title-2="1" AP-title-3="9999" AP-title-4="1" AP-invokeID="0" AE-qualifier="0" AE-invokeID="0" B015_OSI_x0020_Offset="1" Removed_x0020_B015_AUT_x0020_offset="" Removed_x0020_B015_AUT_x0020_Count="" Host_x0020_Name="" />
+        </B015_DIR>
+        <B015_LAT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Local Application Table">
+          <Record Application_x0020_Address="10055" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="0" LAN_x0020_Address_x0020__x0028_hex_x0029_="2747" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="105" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="1" LAN_x0020_Address_x0020__x0028_hex_x0029_="69" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="106" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="2" LAN_x0020_Address_x0020__x0028_hex_x0029_="70" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="107" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="3" LAN_x0020_Address_x0020__x0028_hex_x0029_="71" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="20" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="4" LAN_x0020_Address_x0020__x0028_hex_x0029_="14" Service_x0020_Access_x0020_Point="0" />
+        </B015_LAT>
+        <B015_OSI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="OSI Configuration Table">
+          <Record TPDU_x0020_Size="1024" SDU_x0020_Size="8192" ACK_x0020_Time="1000" Inact_x0020_Time="30000" Ref_x0020_Wait_x0020_Time="10000" Transit_x0020_Delay="100" Max_x0020_Credits="4" Max_x0020_Retrans="5" CLNP_x0020_Lifetime="100" DIB_x0020_Hold_x0020_Time="60000" />
+        </B015_OSI>
+        <B015_RAT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Remote Application Table">
+          <Record Application_x0020_Address="10" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="0" LAN_x0020_Address_x0020__x0028_hex_x0029_="0A" Tx_x0020_Delay_x0020_to_x0020_Application="0" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="50" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="1" LAN_x0020_Address_x0020__x0028_hex_x0029_="32" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="51" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="1" LAN_x0020_Address_x0020__x0028_hex_x0029_="33" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="52" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="1" LAN_x0020_Address_x0020__x0028_hex_x0029_="34" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="60" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="2" LAN_x0020_Address_x0020__x0028_hex_x0029_="3C" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="61" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="2" LAN_x0020_Address_x0020__x0028_hex_x0029_="3D" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="62" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="2" LAN_x0020_Address_x0020__x0028_hex_x0029_="3E" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="70" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="3" LAN_x0020_Address_x0020__x0028_hex_x0029_="46" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="71" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="3" LAN_x0020_Address_x0020__x0028_hex_x0029_="47" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+          <Record Application_x0020_Address="21" Data_x0020_Link_x0020_Name="B013" Data_x0020_Link_x0020_Channel="4" LAN_x0020_Address_x0020__x0028_hex_x0029_="15" Tx_x0020_Delay_x0020_to_x0020_Application="250" Service_x0020_Access_x0020_Point="0" />
+        </B015_RAT>
+      </Application>
+      <Application xsi:type="B021_972:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B021_972="http://www.ge.com/CCE/B021_972" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B021_972 B021_972_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="DNP V3.00 DPA" Application_Type="DPA" Application_Description="Distributed Network Protocol (DNP) V3.00 DPA Configuration." Application_Identifier="B021" Application_Version="972" Application_Revision="0" DCA_Index="-1" Enabled="True">
+        <B021CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DPA Configuration">
+          <Record DPA_x0020_Address="10055" Master_x0020_Address="10" Select_x0020_Time-out="5" Select_x0020_Time-out_x0020__x0028_ms_x0029_="0" SOE_x0020_Buffer_x0020_OV_x0020_Processing="Discard Newest" COS_x0020_Buffer_x0020_Size="100" SOE_x0020_Buffer_x0020_Size="100" COS_x002F_SOE_x0020_Location="RAM" Cntr_x0020_Object_x0020_Report="Absolute" Analog_x0020_Deadband_x0020_Period="0" Analog_x0020_Deadband_x0020_Mode="Absolute Change" Online_x002F_Offline_x0020_Changes="Disabled" Time_x0020_Adj._x0020_Reporting="Disabled" Data_x0020_Link_x0020_Confirm="Disabled" Max_x0020_Req_x0020_Length="2048" Max_x0020_Resp_x0020_Length="2048" Appl_x0020_Turnaround_x0020_Delay="600" Max_x0020_Resp_x0020_Retries="0" Comm_x0020_Fail_x0020_Output_x0020_Pnt="(______) Undefined" Comm_x0020_Fail_x0020_Idle_x0020_Timeout="0" Time_x0020_Sync.="0" Restart_x0020_Delay="10" Save_x0020_Cfg_x0020_Delay="120" Delay_x0020_Meas._x0020_Resp._x0020_Time="500" PRO_x0020_Buffer_x0020_Size="20" PRO_x0020_Buffer_x0020_Location="RAM" Speed_x0020_optimization="Disable" File_x0020_Transfer_x0020_Timeout="20" Buffer_x0020_Frozen_x0020_Counter="FALSE" Frozen_x0020_Counter_x0020_Location="RAM" Frozen_x0020_Counter_x0020_Size="1" Analog_x0020_OV_x0020_Processing="Discard Newest" Analog_x0020_Buffer_x0020_Location="RAM" Reserved="0" Analog_x0020_Buffer_x0020_Size="1" Time_x0020_Sync_x0020_Enable_x0020_DI="(______) Undefined" Time_x0020_Sync_x0020_Enable_x0020_State="OFF" Control_x0020_Group_x0020_Ownership="Automatic" Report_x0020_DI_x0020_with_x0020_Flag="Default" Report_x0020_AI_x0020_with_x0020_Flag="Default" Report_x0020_CTR_x0020_with_x0020_Flag="Default">
+            <DPA_x0020_Points>
+              <Record Num_x0020_Binary_x0020_Inputs="83" First_x0020_Binary_x0020_Input="1" Num_x0020_Binary_x0020_Outputs="64" First_x0020_Binary_x0020_Output="1" Num_x0020_Cntr_x0020_Inputs="0" First_x0020_Cntr_x0020_Input="1" Num_x0020_Frozen_x0020_Cntr_x0020_Inputs="0" First_x0020_Frozen_x0020_Cntr_x0020_Input="1" Num_x0020_Analog_x0020_Inputs="71" First_x0020_Analog_x0020_Input="1" Num_x0020_Analog_x0020_Outputs="0" First_x0020_Analog_x0020_Output="1" Num_x0020_IIN_x0020_Records="0" First_x0020_IIN_x0020_Record="1" Number_x0020_of_x0020_PRO="0" First_x0020_PRO_x0020_Record="1" />
+            </DPA_x0020_Points>
+            <Unsolicited_x0020_Responses>
+              <Record Class_x0020_1="Disabled" Class_x0020_2="Disabled" Class_x0020_3="Disabled" Hold_x0020_Time_x0020__x0028_ms_x0029_="10000" Hold_x0020_Count="10" Idle_x0020_Report_x0020_Period="0" Backoff_x0020_Period_x0020__x0028_ms_x0029_="10000" Silent_x0020_Master="Disabled" Auto_x0020_Data_x0020_Dump="Disabled" UR_x0020_Enable="By Master" filler="" />
+            </Unsolicited_x0020_Responses>
+            <Local_x002F_Remote>
+              <Record Local_x002F_Remote_x0020_Input="(______) Undefined" Local_x0020_Mode_x0020_State="ON" Report_x0020_forced_x002F_OL_x0020_points="Enable RF/OL" Offline_x0020_sets_x0020_Local_x0020_IIN="FALSE" />
+            </Local_x002F_Remote>
+          </Record>
+        </B021CFG>
+        <B021FRZ Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Frozen Counter Input Map" />
+        <B021IIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Internal Indications" />
+        <B021MT01 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Binary Input Map">
+          <Record Binary_x0020_Input_x0020_Point="1" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="2" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="3" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="4" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="5" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="6" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="7" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="8" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="9" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="10" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="11" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="12" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="13" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="14" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="15" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="16" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="17" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="18" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="19" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="20" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="21" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="22" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="23" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="24" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="25" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="26" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="27" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="28" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="29" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="30" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="31" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="32" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="33" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="34" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="35" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="36" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="37" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="38" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="39" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="40" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="41" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="42" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="43" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="(______) Undefined" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="45" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="51" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="47" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="48" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="49" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="50" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="157" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="52" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="53" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="(______) Undefined" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="55" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="56" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="57" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="(______) Undefined" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="(______) Undefined" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="60" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="46" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="158" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="63" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="64" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="65" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="66" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="67" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="68" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="69" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="70" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="71" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="72" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="73" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="74" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="75" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="76" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="77" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="78" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="79" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="80" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="156" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="154" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+          <Record Binary_x0020_Input_x0020_Point="155" Invert_x0020_Status="Disabled" COS="Disabled" SOE="Enabled" Event_x0020_Class="Class 1" />
+        </B021MT01>
+        <B021MT02 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Binary Output Map">
+          <Record Binary_x0020_Output_x0020_Point="1" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="2" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="3" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="4" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="5" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="6" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="7" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="8" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="9" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="10" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="11" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="12" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="13" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="14" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="15" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="16" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="17" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="18" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="19" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="20" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="21" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="22" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="23" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="24" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="25" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="26" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="27" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="28" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="29" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="30" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="31" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="32" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="33" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="34" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="35" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="36" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="37" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="38" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="39" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="40" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="41" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="42" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="43" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="44" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="45" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="46" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="47" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="48" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="49" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="50" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="51" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="52" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="53" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="54" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="55" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="56" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="57" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="58" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="59" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="60" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="61" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="62" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="63" Paired_x0020_Point="(______) Undefined" />
+          <Record Binary_x0020_Output_x0020_Point="64" Paired_x0020_Point="(______) Undefined" />
+        </B021MT02>
+        <B021MT03 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Counter Input Map" />
+        <B021MT04 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map">
+          <Record Analog_x0020_Input_x0020_Point="1" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="2" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="3" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="4" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="5" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="6" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="7" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="8" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="9" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="10" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="11" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="12" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="13" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="14" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="15" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="16" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="17" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="265" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="267" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="20" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="21" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="22" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="23" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="24" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="52" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="53" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="34" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="36" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="37" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="38" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="81" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="82" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="65" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="66" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="67" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="110" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="111" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="94" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="95" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="96" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="139" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="140" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="121" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="123" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="124" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="125" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="168" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="169" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="152" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="153" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="154" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="197" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="198" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="181" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="182" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="183" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="227" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="210" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="211" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="212" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="207" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="208" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="209" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="255" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="256" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="239" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="240" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="241" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="236" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="237" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+          <Record Analog_x0020_Input_x0020_Point="238" Analog_x0020_Size="16" Event_x0020_Class="Class 1" Event_x0020_Deadband="-1" Buffer_x0020_Events="Not Buffered" Time_x0020_Tag="Enabled" Processing_x0020_Options="Current Value and Time" Range="1" Divisor="1" Offset="0" />
+        </B021MT04>
+        <B021MT05 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Map" />
+        <B021MT09 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Complex Object Map" />
+      </Application>
+      <Application xsi:type="B023_746:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B023_746="http://www.ge.com/CCE/B023_746" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B023_746 B023_746_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="DNP V3.00 DCA" Application_Type="DCA" Application_Description="Distributed Network Protocol (DNP) V3.00 DCA Configuration." Application_Identifier="B023" Application_Version="746" Application_Revision="0" DCA_Index="3" Enabled="True">
+        <B023_CFG Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DCA Configuration">
+          <Record DCA_x0020_Index="3" DCA_x0020_Address="105" Minimum_x0020_Inter_x0020_Poll_x0020_Delay="0" Freeze_x0020_to_x0020_Poll_x0020_Delay="1000" Freeze_x0020_and_x0020_Clear="Freeze Frozen ACC" File_x0020_Transfer_x0020_Options="MultiMsg with EOF" FileTransfer_x0020_CFM_x0020_Timeout="10" Number_x0020_of_x0020_Msg_x0020_Buffers="3" First_x0020_Device_x0020_Entry="0" Number_x0020_Of_x0020_Devices="3" Max_x0020_Message_x0020_Size="2048">
+            <Startup_x0020_Timing>
+              <Record Restart_x0020_Delay="10" DCA_x0020_Startup_x0020_Delay="0" Inter_x0020_Dev_x0020_Restart_x0020_Delay="0" />
+            </Startup_x0020_Timing>
+            <DCA_x0020_Mode>
+              <Record Start_x0020_Time="Disable" Round_x0020_Robin_x0020_Poll_x0020_Mode="Disable" Concurrent_x0020_Operation="Disable" />
+            </DCA_x0020_Mode>
+            <Stagger_x0020_Integrity_x0020_Poll>
+              <Record Stagger_x0020_Integrity_x0020_Poll="Disabled" Poll_x0020_Interval_x0020__x0028_Day_x0029_="0" Poll_x0020_Interval_x0020__x0028_Hour_x0029_="0" Poll_x0020_Interval_x0020__x0028_Minute_x0029_="1" Poll_x0020_Interval_x0020__x0028_Seconds_x0029_="0" Poll_x0020_Interval_x0020__x0028_Msec_x0029_="0" />
+            </Stagger_x0020_Integrity_x0020_Poll>
+          </Record>
+          <Record DCA_x0020_Index="4" DCA_x0020_Address="106" Minimum_x0020_Inter_x0020_Poll_x0020_Delay="0" Freeze_x0020_to_x0020_Poll_x0020_Delay="1000" Freeze_x0020_and_x0020_Clear="Freeze Frozen ACC" File_x0020_Transfer_x0020_Options="MultiMsg with EOF" FileTransfer_x0020_CFM_x0020_Timeout="10" Number_x0020_of_x0020_Msg_x0020_Buffers="3" First_x0020_Device_x0020_Entry="3" Number_x0020_Of_x0020_Devices="3" Max_x0020_Message_x0020_Size="2048">
+            <Startup_x0020_Timing>
+              <Record Restart_x0020_Delay="10" DCA_x0020_Startup_x0020_Delay="0" Inter_x0020_Dev_x0020_Restart_x0020_Delay="0" />
+            </Startup_x0020_Timing>
+            <DCA_x0020_Mode>
+              <Record Start_x0020_Time="Disable" Round_x0020_Robin_x0020_Poll_x0020_Mode="Disable" Concurrent_x0020_Operation="Disable" />
+            </DCA_x0020_Mode>
+            <Stagger_x0020_Integrity_x0020_Poll>
+              <Record Stagger_x0020_Integrity_x0020_Poll="Disabled" Poll_x0020_Interval_x0020__x0028_Day_x0029_="0" Poll_x0020_Interval_x0020__x0028_Hour_x0029_="0" Poll_x0020_Interval_x0020__x0028_Minute_x0029_="1" Poll_x0020_Interval_x0020__x0028_Seconds_x0029_="0" Poll_x0020_Interval_x0020__x0028_Msec_x0029_="0" />
+            </Stagger_x0020_Integrity_x0020_Poll>
+          </Record>
+          <Record DCA_x0020_Index="5" DCA_x0020_Address="107" Minimum_x0020_Inter_x0020_Poll_x0020_Delay="0" Freeze_x0020_to_x0020_Poll_x0020_Delay="1000" Freeze_x0020_and_x0020_Clear="Freeze Frozen ACC" File_x0020_Transfer_x0020_Options="MultiMsg with EOF" FileTransfer_x0020_CFM_x0020_Timeout="10" Number_x0020_of_x0020_Msg_x0020_Buffers="3" First_x0020_Device_x0020_Entry="6" Number_x0020_Of_x0020_Devices="2" Max_x0020_Message_x0020_Size="2048">
+            <Startup_x0020_Timing>
+              <Record Restart_x0020_Delay="10" DCA_x0020_Startup_x0020_Delay="0" Inter_x0020_Dev_x0020_Restart_x0020_Delay="0" />
+            </Startup_x0020_Timing>
+            <DCA_x0020_Mode>
+              <Record Start_x0020_Time="Disable" Round_x0020_Robin_x0020_Poll_x0020_Mode="Disable" Concurrent_x0020_Operation="Disable" />
+            </DCA_x0020_Mode>
+            <Stagger_x0020_Integrity_x0020_Poll>
+              <Record Stagger_x0020_Integrity_x0020_Poll="Disabled" Poll_x0020_Interval_x0020__x0028_Day_x0029_="0" Poll_x0020_Interval_x0020__x0028_Hour_x0029_="0" Poll_x0020_Interval_x0020__x0028_Minute_x0029_="1" Poll_x0020_Interval_x0020__x0028_Seconds_x0029_="0" Poll_x0020_Interval_x0020__x0028_Msec_x0029_="0" />
+            </Stagger_x0020_Integrity_x0020_Poll>
+          </Record>
+          <Record DCA_x0020_Index="6" DCA_x0020_Address="20" Minimum_x0020_Inter_x0020_Poll_x0020_Delay="0" Freeze_x0020_to_x0020_Poll_x0020_Delay="1000" Freeze_x0020_and_x0020_Clear="Freeze Frozen ACC" File_x0020_Transfer_x0020_Options="MultiMsg with EOF" FileTransfer_x0020_CFM_x0020_Timeout="10" Number_x0020_of_x0020_Msg_x0020_Buffers="3" First_x0020_Device_x0020_Entry="8" Number_x0020_Of_x0020_Devices="1" Max_x0020_Message_x0020_Size="2048">
+            <Startup_x0020_Timing>
+              <Record Restart_x0020_Delay="10" DCA_x0020_Startup_x0020_Delay="0" Inter_x0020_Dev_x0020_Restart_x0020_Delay="0" />
+            </Startup_x0020_Timing>
+            <DCA_x0020_Mode>
+              <Record Start_x0020_Time="Disable" Round_x0020_Robin_x0020_Poll_x0020_Mode="Disable" Concurrent_x0020_Operation="Disable" />
+            </DCA_x0020_Mode>
+            <Stagger_x0020_Integrity_x0020_Poll>
+              <Record Stagger_x0020_Integrity_x0020_Poll="Disabled" Poll_x0020_Interval_x0020__x0028_Day_x0029_="0" Poll_x0020_Interval_x0020__x0028_Hour_x0029_="0" Poll_x0020_Interval_x0020__x0028_Minute_x0029_="1" Poll_x0020_Interval_x0020__x0028_Seconds_x0029_="0" Poll_x0020_Interval_x0020__x0028_Msec_x0029_="0" />
+            </Stagger_x0020_Integrity_x0020_Poll>
+          </Record>
+        </B023_CFG>
+        <B023_DEV Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Configuration">
+          <Record Application_x0020_Address="50" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="51" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="52" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="60" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="61" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="62" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="70" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="71" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="0" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+          <Record Application_x0020_Address="21" Device_x0020_Processing_x0020_Delay="600" Feedback_x0020_poll_x0020_delay="1000" Time_x0020_Sync_x0020_Method="No Time Sync" Failures_x0020_For_x0020_bad_x0020_Channel="3" Alt_x0020_Chan_x0020_Check_x0020_Interval="0">
+            <Device_x0020_Mode>
+              <Record Polls="Enable" Start_Time="Disable" Setpoint_x0020_Control="Disable" Control_x0020_Option="Direct Operate" Timesyncing="Disable" Multiple_x0020_Command="Disable" Device="Enable" Data_x0020_Link_x0020_CFM_x0020_Required="Confirm Not Required" Off-Line_x0020_After_x0020_Fail="Off-line after chan fail" Extended_x0020_feedback_x0020_Poll="Enable Ext Feedback" Device_x0020_Type="Individual" />
+            </Device_x0020_Mode>
+            <Start_x0020_Time>
+              <Record Start_x0020_Time_x0020__x0028_Hour_x0029_="0" Start_x0020_Time_x0020__x0028_Minute_x0029_="0" Start_x0020_Time_x0020__x0028_Second_x0029_="0" />
+            </Start_x0020_Time>
+            <Device_x0020_Configuration>
+              <Record Configuration_x0020_Table_x0020_Name="" Table_x0020_Record="0" First_x0020_Point_x0020_Record="1" Number_x0020_of_x0020_Point_x0020_Records="1" First_x0020_Poll_x0020_Record="0" Number_x0020_of_x0020_Poll_x0020_Records="1" />
+            </Device_x0020_Configuration>
+            <Pseudo_x0020_BI_x0020_Events>
+              <Record Events_x0020_for_x0020_Enable_x0020_Device="Enabled" Events_x0020_for_x0020_Enable_x0020_Poll="Enabled" Events_x0020_for_x0020_Enable_x0020_Unsol="Enabled" Events_x0020_for_x0020_Poll_x0020_Device="Enabled" Events_x0020_for_x0020_Restart_x0020_Dev="Enabled" Events_x0020_for_x0020_Time_x0020_Sync="Disabled" Events_x0020_for_x0020_Delay_x0020_Meas="Enabled" Events_x0020_for_x0020_PrimeChStatus="Enabled" Events_x0020_for_x0020_SecChStatus="Enabled" Events_x0020_for_x0020_PrimChInUse="Enabled" Events_x0020_for_x0020_SecChInUse="Enabled" />
+            </Pseudo_x0020_BI_x0020_Events>
+          </Record>
+        </B023_DEV>
+        <B023_PNT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Point Map">
+          <Record DCA_x0020_Object_x0020_Type="Analog Input 16" Number_x0020_Of_x0020_Device_x0020_Points="24" />
+          <Record DCA_x0020_Object_x0020_Type="Analog Input 16" Number_x0020_Of_x0020_Device_x0020_Points="3" />
+        </B023_PNT>
+        <B023_POL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Poll">
+          <Record Poll_x0020_Data_x0020_Type="Integrity Poll" Qualifier="ALL Points" Start_x0020_Point="0" Number_x0020_of_x0020_Points="1" Poll_x0020_Interval_x0020__x0028_Days_x0029_="0" Poll_x0020_Interval_x0020__x0028_Hours_x0029_="0" Poll_x0020_Interval_x0020__x0028_Minutes_x0029_="0" Poll_x0020_Interval_x0020__x0028_Seconds_x0029_="5" Poll_x0020_Interval_x0020__x0028_Msec_x0029_="0" />
+        </B023_POL>
+      </Application>
+      <Application xsi:type="B034_203:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B034_203="http://www.ge.com/CCE/B034_203" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B034_203 B034_203_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Redundant Monitor" Application_Type="DTA" Application_Description="Redundant monitor configuration." Application_Identifier="B034" Application_Version="203" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <B034_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Port Configuration">
+          <Record />
+        </B034_COM>
+      </Application>
+      <Application xsi:type="B062-0_121:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B062-0_121="http://www.ge.com/CCE/B062-0_121" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B062-0_121 B062-0_121_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Data Display DTA" Application_Type="DTA" Application_Description="Remote Point Data Display" Application_Identifier="B062-0" Application_Version="121" Application_Revision="0" DCA_Index="20" Enabled="False">
+        <B062COMM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Communication Port">
+          <Record />
+        </B062COMM>
+        <B062_AI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Map">
+          <Record Analog_x0020_Input="(______) Undefined" />
+        </B062_AI>
+        <B062_DI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Binary Input Map" />
+        <B062DISP Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Display Config">
+          <Record />
+        </B062DISP>
+        <B062MAIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Display Main">
+          <Record />
+        </B062MAIN>
+      </Application>
+      <Application xsi:type="B071-0_200:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B071-0_200="http://www.ge.com/CCE/B071-0_200" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B071-0_200 B071-0_200_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="WESMAINT File Upload" Application_Type="DPA" Application_Description="Uploads files via the WESMAINT port as S records or using ZMODEM." Application_Identifier="B071-0" Application_Version="200" Application_Revision="0" DCA_Index="-1" Enabled="False">
+        <B071WTXT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Localized Text">
+          <Record />
+        </B071WTXT>
+      </Application>
+      <Application xsi:type="B082-1_210:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:B082-1_210="http://www.ge.com/CCE/B082-1_210" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/B082-1_210 B082-1_210_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="LogicLinx (no Ethernet)" Application_Type="DTA" Application_Description="IEC 61131-3 Soft Logic Application" Application_Identifier="B082-1" Application_Version="210" Application_Revision="0" DCA_Index="21" Enabled="False">
+        <B082_COM Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Communications Type">
+          <Record>
+            <Serial_x0020_Flags>
+              <Record />
+            </Serial_x0020_Flags>
+          </Record>
+        </B082_COM>
+        <AIC_TAGS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="AI Conversion Point Tags" />
+        <AOC_TAGS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="AO Conversion Point Tags" />
+        <B082_AI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Input Mapping" />
+        <B082_AO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Analog Output Mapping" />
+        <B082_CN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Transition Counter Map" />
+        <B082_DCA Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="LogicLinx DCA Index">
+          <Record />
+        </B082_DCA>
+        <B082_DI Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Input Mapping" />
+        <B082_DO Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Output Mapping" />
+        <B082_ITC Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Internal DI Counters" />
+        <B082AOIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="AO Initial Values Table" />
+        <B082DOIN Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DO Initial Values Table" />
+        <B082DOTY Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Digital Output Type" />
+        <CNC_TAGS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="CN Conversion Point Tags" />
+        <DIC_TAGS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DI Conversion Point Tags" />
+        <DOC_TAGS Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DO Conversion Point Tags" />
+      </Application>
+      <Application xsi:type="CPRO_600:ApplicationType" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="11.0" xmlns:CPRO_600="http://www.ge.com/CCE/CPRO_600" xmlns:abs="http://www.ge.com/CCE/ApplSchema" xsi:schemaLocation="http://www.ge.com/CCE/CPRO_600 CPRO_600_AE.xsd http://www.ge.com/CCE/ApplSchema ApplicationBaseSchema.xsd" Application_Name="Config Pro Tables" Application_Type="DPA" Application_Description="Config Pro internal tables." Application_Identifier="CPRO" Application_Version="600" Application_Revision="0" DCA_Index="-1" Enabled="True">
+        <CFG_ACR Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="ACR Configuration">
+          <Record Octart_x0020_Channel_x0020_A_x0026_B="0" Octart_x0020_Channel_x0020_C_x0026_D="0" Octart_x0020_Channel_x0020_E_x0026_F="0" Octart_x0020_Channel_x0020_G_x0026_H="0" />
+        </CFG_ACR>
+        <CFG_B003 Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Peripheral Extra Info">
+          <Record Slot_x0020_Number="0" Part_x0020_Number="00000" Term_x0020_Board_x0020_Type="1" Created_x0020_Date="1044578304" Modified_x0020_Date="1095237632" Rack_x0020_Number="" Rack_x0020_Position="" />
+          <Record Slot_x0020_Number="1" Part_x0020_Number="00000" Term_x0020_Board_x0020_Type="3" Created_x0020_Date="852426752" Modified_x0020_Date="1520260937" Rack_x0020_Number="" Rack_x0020_Position="" />
+          <Record Slot_x0020_Number="2" Part_x0020_Number="00000" Term_x0020_Board_x0020_Type="3" Created_x0020_Date="1044578304" Modified_x0020_Date="1044578304" Rack_x0020_Number="" Rack_x0020_Position="" />
+          <Record Slot_x0020_Number="3" Part_x0020_Number="00000" Term_x0020_Board_x0020_Type="5" Created_x0020_Date="1044578304" Modified_x0020_Date="1279614291" Rack_x0020_Number="" Rack_x0020_Position="" />
+          <Record Slot_x0020_Number="4" Part_x0020_Number="00000" Term_x0020_Board_x0020_Type="5" Created_x0020_Date="1044578304" Modified_x0020_Date="1044578304" Rack_x0020_Number="" Rack_x0020_Position="" />
+        </CFG_B003>
+        <CFG_DEV Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Connection Info" />
+        <CFG_DTP Table_Enabled="False" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device Termination Point">
+          <Record Point_x0020_Type="0" DCA_x0020_Position="0" DCA_x0020_Instance="0" Module_x0020_Number="0" Group_x0020_Number="0" Local_x0020_Point="0" Polarity="" Term_x0020_Ref_x0020_ID="" Termiation_x0020_Block="" Ext_x0020_Point_x0020_Type="" Tag_x0020_1_x0020_Description="" Tag_x0020_2_x0020_Description="" Tag_x0020_3_x0020_Description="" />
+        </CFG_DTP>
+        <CFG_WAL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Applications Info">
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A001" Application_x0020_Version="701" Application_x0020_Name="Conitel C2020/C2000" Application_x0020_Flags="0" Modified_x0020_Date="859439104" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A004-1" Application_x0020_Version="303" Application_x0020_Name="TRW S-9000" Application_x0020_Flags="0" Modified_x0020_Date="876675072" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A016-0" Application_x0020_Version="200" Application_x0020_Name="Conitel 3000 Protocol" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A017" Application_x0020_Version="131" Application_x0020_Name="DNP V1.00" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A018" Application_x0020_Version="120" Application_x0020_Name="Quantum Meter Scanner" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A020" Application_x0020_Version="421" Application_x0020_Name="HR6000 DCA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A022" Application_x0020_Version="203" Application_x0020_Name="SC 1801 DPA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A025" Application_x0020_Version="302" Application_x0020_Name="Conitel C0300" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A026-1" Application_x0020_Version="321" Application_x0020_Name="Communication Watchdog" Application_x0020_Flags="1" Modified_x0020_Date="1416521414" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A027" Application_x0020_Version="810" Application_x0020_Name="SOE Logger DTA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A029" Application_x0020_Version="707" Application_x0020_Name="CDC Type II" Application_x0020_Flags="0" Modified_x0020_Date="1044316160" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A030" Application_x0020_Version="300" Application_x0020_Name="Accumulator Freeze" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A031" Application_x0020_Version="310" Application_x0020_Name="TRW 9550" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A035" Application_x0020_Version="211" Application_x0020_Name="Analog Reference" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A036" Application_x0020_Version="421" Application_x0020_Name="ProLogic Executor" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A059" Application_x0020_Version="902" Application_x0020_Name="Modbus DCA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A068" Application_x0020_Version="229" Application_x0020_Name="Modbus DPA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A078" Application_x0020_Version="609" Application_x0020_Name="SEL Gateway DCA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A083-0" Application_x0020_Version="335" Application_x0020_Name="Calculator DTA" Application_x0020_Flags="1" Modified_x0020_Date="1520261479" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A092-0" Application_x0020_Version="103" Application_x0020_Name="DPU DCA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A185-0" Application_x0020_Version="200" Application_x0020_Name="W18979 DPA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A194-0" Application_x0020_Version="100" Application_x0020_Name="Cooper 2179 DCA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="A199-0" Application_x0020_Version="103" Application_x0020_Name="HR6000/XA-21" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B003" Application_x0020_Version="749" Application_x0020_Name="D.20 Peripheral Link" Application_x0020_Flags="65" Modified_x0020_Date="1520266918" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B008-1" Application_x0020_Version="304" Application_x0020_Name="System Point Database" Application_x0020_Flags="3" Modified_x0020_Date="1520265871" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B009" Application_x0020_Version="400" Application_x0020_Name="Mailbox DTA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B012" Application_x0020_Version="112" Application_x0020_Name="IRIG-B" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B013" Application_x0020_Version="541" Application_x0020_Name="DNP V3.00 Data Link" Application_x0020_Flags="1" Modified_x0020_Date="1491223534" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B014-1" Application_x0020_Version="412" Application_x0020_Name="Wesmaint II+" Application_x0020_Flags="1" Modified_x0020_Date="1465602423" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B015" Application_x0020_Version="520" Application_x0020_Name="Bridgeman" Application_x0020_Flags="1" Modified_x0020_Date="1491224444" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B021" Application_x0020_Version="972" Application_x0020_Name="DNP V3.00 DPA" Application_x0020_Flags="1" Modified_x0020_Date="1520261477" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B023" Application_x0020_Version="746" Application_x0020_Name="DNP V3.00 DCA" Application_x0020_Flags="1" Modified_x0020_Date="1490715890" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B034" Application_x0020_Version="203" Application_x0020_Name="Redundant Monitor" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B062-0" Application_x0020_Version="121" Application_x0020_Name="Data Display DTA" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B071-0" Application_x0020_Version="200" Application_x0020_Name="WESMAINT File Upload" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="B082-1" Application_x0020_Version="210" Application_x0020_Name="LogicLinx (no Ethernet)" Application_x0020_Flags="0" Modified_x0020_Date="852426752" />
+          <Record Processor_x0020_Number="0" Application_x0020_ID="CPRO" Application_x0020_Version="600" Application_x0020_Name="Config Pro Tables" Application_x0020_Flags="1" Modified_x0020_Date="854851584" />
+        </CFG_WAL>
+        <CFG_WDL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Device General Info">
+          <Record Description="Flanders Substation" Device_x0020_Type="0" Created_x0020_Date="0" Modified_x0020_Date="1520266918" Serial_x0020_Number="SAD8686/00" Bitmap_x0020_Name="D20ME" Device_x0020_Flags="32792" LAN_x0020_Segment="1" />
+        </CFG_WDL>
+        <CFG_WFL Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Firmware General Info">
+          <Record Processor_x0020_Number="0" Firmware_x0020_Name="SAB3075" Firmware_x0020_Version="010" Description="P038-0 v3.53, P026-1 v2.91, MODBUS\8979\DNP" Programmer="Repeat Firmware" Created_x0020_Date="848101376" Modified_x0020_Date="1095237632" Applications="36" />
+        </CFG_WFL>
+        <CFGDOEXT Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="DO Extented Point Type">
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+          <Record Processor_x0020_Number="0" Extended_x0020_Point_x0020_Type="0" />
+        </CFGDOEXT>
+        <S061IBOX Table_Enabled="True" Table_Modified_Date="" Table_Default_Config="" Table_Name="Com Port Type">
+          <Record Com_x0020_Port="COM1" Port_x0020_Type="RS-232" Connection="Two-wire" />
+          <Record Com_x0020_Port="COM1" Port_x0020_Type="RS-232" Connection="Two-wire" />
+          <Record Com_x0020_Port="COM1" Port_x0020_Type="RS-232" Connection="Two-wire" />
+        </S061IBOX>
+      </Application>
+      <Peripheral_Link>
+        <Line Content="[D.20]" />
+        <Line Content="Redundant CCU=0" />
+        <Line Content="Odd Address Parity=0" />
+        <Line Content="Standby Accumulators=0" />
+        <Line Content="Peripheral Status Points=0" />
+        <Line Content="Communication Statistic Points=0" />
+        <Line Content="[D.20AC0]" />
+        <Line Content="Unbalanced Alarms Points=0" />
+        <Line Content="[D.20AC2]" />
+        <Line Content="Unbalanced Alarms Points=0" />
+      </Peripheral_Link>
+    </Processor>
+  </Processor_List>
+  <Firmware_List>
+    <Firmware Id="SAB3075" Version="010" Description="P038-0 v3.53, P026-1 v2.91, MODBUS\8979\DNP" Programmer="Repeat Firmware" Create_Date="Apr 13, 2005" Modified_Date="Oct 08, 2012">
+      <Application Id="A001" Version="701" />
+      <Application Id="A004-1" Version="303" />
+      <Application Id="A016-0" Version="200" />
+      <Application Id="A017" Version="131" />
+      <Application Id="A018" Version="120" />
+      <Application Id="A020" Version="421" />
+      <Application Id="A022" Version="203" />
+      <Application Id="A025" Version="302" />
+      <Application Id="A026-1" Version="321" />
+      <Application Id="A027" Version="810" />
+      <Application Id="A029" Version="707" />
+      <Application Id="A030" Version="300" />
+      <Application Id="A031" Version="310" />
+      <Application Id="A035" Version="211" />
+      <Application Id="A036" Version="421" />
+      <Application Id="A059" Version="902" />
+      <Application Id="A068" Version="229" />
+      <Application Id="A078" Version="609" />
+      <Application Id="A083-0" Version="335" />
+      <Application Id="A092-0" Version="103" />
+      <Application Id="A185-0" Version="200" />
+      <Application Id="A194-0" Version="100" />
+      <Application Id="A199-0" Version="103" />
+      <Application Id="B003" Version="749" />
+      <Application Id="B008-1" Version="304" />
+      <Application Id="B009" Version="400" />
+      <Application Id="B012" Version="112" />
+      <Application Id="B013" Version="541" />
+      <Application Id="B014-1" Version="412" />
+      <Application Id="B015" Version="520" />
+      <Application Id="B021" Version="972" />
+      <Application Id="B023" Version="746" />
+      <Application Id="B034" Version="203" />
+      <Application Id="B062-0" Version="121" />
+      <Application Id="B071-0" Version="200" />
+      <Application Id="B082-1" Version="210" />
+    </Firmware>
+  </Firmware_List>
+  <Ini_File>
+    <Line Content="[Communications]" />
+    <Line Content="Type=0" />
+    <Line Content="Port=0" />
+    <Line Content="BaudRate=9600" />
+    <Line Content="Parity=0" />
+    <Line Content="DataBits=8" />
+    <Line Content="StopBits=1" />
+    <Line Content="FlowControl=12" />
+    <Line Content="LanAPreferred=True" />
+    <Line Content="FileTransferBaudRateEnabled=False" />
+    <Line Content="FileTransferBaudRate=115200" />
+    <Line Content="[Modem]" />
+    <Line Content="PhoneNumber=" />
+    <Line Content="ModemType=" />
+    <Line Content="DialTimeout=60" />
+    <Line Content="RetryTimeout=120" />
+    <Line Content="MaxRetries=10" />
+    <Line Content="InitCmd=" />
+    <Line Content="DialCmd=" />
+    <Line Content="DialTerm=" />
+    <Line Content="DialCancel=" />
+    <Line Content="HangupCmd=" />
+    <Line Content="ConfigCmd=" />
+    <Line Content="AnswerCmd=" />
+    <Line Content="OKMsg=" />
+    <Line Content="ConnectMsg=" />
+    <Line Content="BusyMsg=" />
+    <Line Content="VoiceMsg=" />
+    <Line Content="NoCarrierMsg=" />
+    <Line Content="NoDialMsg=" />
+    <Line Content="ErrorMsg=" />
+    <Line Content="RingMsg=" />
+    <Line Content="AfterConnect=" />
+    <Line Content="DefBaud=9600" />
+    <Line Content="LockDTE=False" />
+    <Line Content="[GlobalMemory]" />
+    <Line Content="StartAddress=5242880" />
+    <Line Content="Size=8" />
+    <Line Content="NVRAMSize=2048" />
+    <Line Content="RAMSize=0" />
+    <Line Content="BaseSize=1024" />
+    <Line Content="NVRAMStorageRegions=0" />
+    <Line Content="NVRAMStorageRegionSize=0" />
+    <Line Content="[Proc #1]" />
+    <Line Content="Enabled=True" />
+    <Line Content="FirmwareName=SAB3075" />
+    <Line Content="FirmwareVer=010" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=526-2007 CCU" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=1048576" />
+    <Line Content="EPROMSize=2097152" />
+    <Line Content="NVRAMBase=8388608" />
+    <Line Content="NVRAMSize=524288" />
+    <Line Content="RAMBase=3145728" />
+    <Line Content="RAMSize=1572864" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[Proc #2]" />
+    <Line Content="Enabled=False" />
+    <Line Content="FirmwareName=" />
+    <Line Content="FirmwareVer=" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=0" />
+    <Line Content="EPROMSize=0" />
+    <Line Content="NVRAMBase=0" />
+    <Line Content="NVRAMSize=0" />
+    <Line Content="RAMBase=0" />
+    <Line Content="RAMSize=0" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[Proc #3]" />
+    <Line Content="Enabled=False" />
+    <Line Content="FirmwareName=" />
+    <Line Content="FirmwareVer=" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=0" />
+    <Line Content="EPROMSize=0" />
+    <Line Content="NVRAMBase=0" />
+    <Line Content="NVRAMSize=0" />
+    <Line Content="RAMBase=0" />
+    <Line Content="RAMSize=0" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[Proc #4]" />
+    <Line Content="Enabled=False" />
+    <Line Content="FirmwareName=" />
+    <Line Content="FirmwareVer=" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=0" />
+    <Line Content="EPROMSize=0" />
+    <Line Content="NVRAMBase=0" />
+    <Line Content="NVRAMSize=0" />
+    <Line Content="RAMBase=0" />
+    <Line Content="RAMSize=0" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[Proc #5]" />
+    <Line Content="Enabled=False" />
+    <Line Content="FirmwareName=" />
+    <Line Content="FirmwareVer=" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=0" />
+    <Line Content="EPROMSize=0" />
+    <Line Content="NVRAMBase=0" />
+    <Line Content="NVRAMSize=0" />
+    <Line Content="RAMBase=0" />
+    <Line Content="RAMSize=0" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[Proc #6]" />
+    <Line Content="Enabled=False" />
+    <Line Content="FirmwareName=" />
+    <Line Content="FirmwareVer=" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=0" />
+    <Line Content="EPROMSize=0" />
+    <Line Content="NVRAMBase=0" />
+    <Line Content="NVRAMSize=0" />
+    <Line Content="RAMBase=0" />
+    <Line Content="RAMSize=0" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[Proc #7]" />
+    <Line Content="Enabled=False" />
+    <Line Content="FirmwareName=" />
+    <Line Content="FirmwareVer=" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=0" />
+    <Line Content="EPROMSize=0" />
+    <Line Content="NVRAMBase=0" />
+    <Line Content="NVRAMSize=0" />
+    <Line Content="RAMBase=0" />
+    <Line Content="RAMSize=0" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[Proc #8]" />
+    <Line Content="Enabled=False" />
+    <Line Content="FirmwareName=" />
+    <Line Content="FirmwareVer=" />
+    <Line Content="Description=" />
+    <Line Content="PartNumber=" />
+    <Line Content="DeriveMemoryModel=True" />
+    <Line Content="EPROMBase=0" />
+    <Line Content="EPROMSize=0" />
+    <Line Content="NVRAMBase=0" />
+    <Line Content="NVRAMSize=0" />
+    <Line Content="RAMBase=0" />
+    <Line Content="RAMSize=0" />
+    <Line Content="DeriveApplications=True" />
+    <Line Content="UserEPROMImageFile=True" />
+    <Line Content="EPROMImageFile=" />
+    <Line Content="[VME #1]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #2]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #3]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #4]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #5]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #6]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #7]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #8]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #9]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #10]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #11]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #12]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #13]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #14]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #15]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[VME #16]" />
+    <Line Content="Processor=0" />
+    <Line Content="Type=0" />
+    <Line Content="Address=0" />
+    <Line Content="[D25]" />
+    <Line Content="PartNumber=Z112000000UUUUU" />
+    <Line Content="LineFrequency=60" />
+    <Line Content="FilterEnable=False" />
+    <Line Content="MaxDSPFailures=2" />
+    <Line Content="DSPFailureWindow=3600000" />
+    <Line Content="Max68HC11Failures=3" />
+    <Line Content="68HC11FailureWindow=3600000" />
+    <Line Content="MaxControlFailures=1" />
+    <Line Content="ControlFailureWindow=3600000" />
+    <Line Content="SIOConfig=0" />
+    <Line Content="ACAnalogAveraging=60" />
+    <Line Content="OnLineConfigTimeout=15" />
+    <Line Content="DiagnosticLevel=0" />
+    <Line Content="RAMStartAddress=8388608" />
+    <Line Content="BaseSystemArea=32" />
+    <Line Content="NVRAMArea=512" />
+    <Line Content="ACCircuitForcedReportingInterval=0" />
+    <Line Content="RestartHC11WhenHSCIFails=1" />
+    <Line Content="ACDataTimeTagOption=2" />
+    <Line Content="UsingD25Gen5MainBoard=False" />
+    <Line Content="[LAN]" />
+    <Line Content="BOOTPType=1" />
+    <Line Content="BOOTPWindow=180" />
+    <Line Content="BufferSize=64" />
+    <Line Content="ResponseDelayA=0" />
+    <Line Content="ResponseDelayB=5" />
+    <Line Content="HostAddressA=0.0.0.0" />
+    <Line Content="EthernetAddressA=0.0.0.0.0.0" />
+    <Line Content="HostAddressB=0.0.0.0" />
+    <Line Content="EthernetAddressB=0.0.0.0.0.0" />
+    <Line Content="HostName=" />
+    <Line Content="[Language]" />
+    <Line Content="LCID=1033" />
+    <Line Content="[Miscellaneous]" />
+    <Line Content="ConfigVersion=127" />
+    <Line Content="[Terminal]" />
+    <Line Content="Emulation=1" />
+    <Line Content="InactivityTimeout=0" />
+    <Line Content="UploadTimeout=20" />
+    <Line Content="[TFTP]" />
+    <Line Content="ReceiveTimeout=2000" />
+    <Line Content="MaxRetries=5" />
+    <Line Content="BlockSize=2048" />
+    <Line Content="Inactivity Timeout=0" />
+    <Line Content="DUN PhoneBook Entry=" />
+    <Line Content="Maximum Log Size=32000" />
+    <Line Content="Maintain Log=False" />
+    <Line Content="PPPPingTimeout=2000" />
+    <Line Content="Monitor Delay=2" />
+    <Line Content="[General]" />
+    <Line Content="DeviceName=FLANDERH" />
+  </Ini_File>
+</CCE:Device>


### PR DESCRIPTION
- Add analog-input-16-validation.json: Complete DSL nodeValidation example
  - Validates Analog Input 16 point counts per DCA CONFIGURATION record
  - Uses expectedValueExpression for dynamic comparison against B008_DCA records
  - Demonstrates complex mapping and point count adjustments
- Add FLANDERH.xml: Sample XML file for testing DSL validations
- Add example output reports showing successful validation results

This demonstrates advanced DSL features including:
- nodeValidation type with per-node results
- Dynamic XPath construction with concat and add operations
- expectedValueExpression for computed expected values
- Complex XML node mapping and filtering

🤖 Generated with [Claude Code](https://claude.ai/code)